### PR TITLE
Integrated editor into page

### DIFF
--- a/app/public/css/editor.css
+++ b/app/public/css/editor.css
@@ -1,0 +1,142 @@
+#editor {
+  margin: 20px;
+  padding: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  height: 600px;
+  position: relative;
+  border: 1px solid #333;
+}
+#editor .header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
+  font-size: 16px;
+  padding: 6px 10px;
+  background-color: #00a;
+  color: #fff;
+}
+#editor .header .alert {
+  color: #fff;
+  font-size: 14px;
+  padding: 3px 6px;
+  margin-left: 10px;
+}
+#editor .header .alert-error {
+  background-color: #f00;
+}
+#editor .header .alert-warning {
+  background-color: #700;
+}
+#editor .header .alert-info {
+  background-color: #070;
+}
+
+#editor .toolbar {
+  position: absolute;
+  top: 30px;
+  left: 0;
+  right: 0;
+  background-color: #aaa;
+  padding: 7px 10px;
+  height: 40px;
+}
+#editor .toolbar span {
+  float: left;
+  cursor: pointer;
+  padding: 5px 10px;
+  margin-right: 10px;
+  color: #fff;
+  background-color: #007;
+  font-size: 14px;
+}
+#editor .toolbar span.disabled {
+  color: #000;
+  background-color: #eee;
+  cursor: not-allowed;
+}
+#editor .toolbar span.right {
+  float: right;
+}
+#editor .text {
+  position: absolute;
+  top: 75px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+#editor .CodeMirror {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+  margin: 0;
+  font: 14px monospace;
+}
+#editor .dialog {
+  position: absolute;
+  top: 100px;
+  left: 100px;
+  width: 600px;
+  height: 400px;
+  background-color: #aaa;
+  z-index: 100;
+}
+
+#editor .dialog .title {
+  background-color: #00a;
+  padding: 5px;
+  color: #fff;
+}
+#editor .dialog .title .close {
+  padding: 2px 5px;
+  font-size: 12px;
+  background-color: #f00;
+  color: #fff;
+  float: right;
+  cursor: pointer;
+}
+#editor .dialog .inner {
+  margin: 10px;
+}
+#editor .dialog .inner .filelist {
+  position: absolute;
+  top: 38px;
+  left: 10px;
+  right: 10px;
+  bottom: 50px;
+  background-color: #f7f7f7;
+  overflow: auto;
+  padding: 10px 0 10px 10px;
+}
+#editor .dialog .inner .filelist .fileheader {
+  font-size: 14px;
+  font-weight: bold;
+}
+#editor .dialog .inner .filelist .filelistitem {
+  cursor: pointer;
+  margin: 5px;
+  font-size: 14px;
+}
+#editor .dialog .inner .fileinput {
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  height: 25px;
+  width: 485px;
+  font-size: 14px;
+}
+#editor .dialog .inner .button {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  height: 30px;
+  width: 80px;
+}

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -10,6 +10,21 @@
     <script src='https://cdn.firebase.com/js/client/1.0.15/firebase.js'></script>
 
     <script src="vendor/breadboard/js/sparks.js"></script>
+
+    <!-- for editor -->
+    <link href="vendor/codemirror/lib/codemirror.css" media="all" rel="stylesheet" />
+    <link href="vendor/codemirror/addon/lint/lint.css" media="all" rel="stylesheet" />
+    <link href="css/editor.css" media="all" rel="stylesheet" />
+    <script src="vendor/codemirror/lib/codemirror.js"></script>
+    <script src="vendor/codemirror/mode/javascript/javascript.js"></script>
+    <script src="vendor/codemirror/addon/edit/matchbrackets.js"></script>
+    <script src="vendor/codemirror/addon/edit/closebrackets.js"></script>
+    <script src="vendor/jsonlint/lib/jsonlint.js"></script>
+    <script src="vendor/codemirror/addon/lint/lint.js"></script>
+    <script src="vendor/codemirror/addon/lint/json-lint.js"></script>
+    <script src='https://cdn.firebase.com/js/client/1.0.15/firebase.js'></script>
+    <script src="https://cdn.firebase.com/js/simple-login/1.6.4/firebase-simple-login.js"></script>
+
   </head>
   <body>
     <div id="content"></div>

--- a/app/src/views/editor.js
+++ b/app/src/views/editor.js
@@ -1,0 +1,580 @@
+var div = React.DOM.div,
+    span = React.DOM.span,
+    italics = React.DOM.i,
+    storagePrefix = 'local:',
+    loginKey = 'editor:login',
+    Header, Toolbar, Editor, Dialog;
+
+module.exports = React.createClass({
+
+  displayName: 'EditorView',
+  
+  componentDidMount: function() {
+    var rawLoginInfo = localStorage.getItem(loginKey),
+        loginInfo = rawLoginInfo ? JSON.parse(rawLoginInfo) : null;
+    if (loginInfo && loginInfo.email && loginInfo.password) {
+      this.login(loginInfo.email, loginInfo.password);
+    }
+  },
+
+  getInitialState: function () {
+    var state = this.getEmptyState();
+    state.showDialog = false;
+    this.firebase = new Firebase('https://teaching-teamwork.firebaseio.com/dev/');
+    this.authClient = null;
+    this.remoteUrlWatcher = null;
+    return state;
+  },
+
+  getEmptyState: function () {
+    return {
+      filename: null,
+      dirty: false,
+      empty: true,
+      text: this.getEmptyDoc(),
+      newed: true,
+      user: this.state ? this.state.user : null,
+      username: this.state ? this.state.username : null,
+      remoteUrl: null,
+      via: null,
+      published: false
+    };
+  },
+
+  getEmptyDoc: function () {
+    return JSON.stringify({
+      "name": "",
+      "externalComponents": [],
+      "clients": []
+    }, null, 2);
+  },
+
+  okIfDirty: function () {
+    if (this.state.dirty) {
+      return confirm('The current activity is not saved.  Are you sure you want to continue?');
+    }
+    return true;
+  },
+
+  hideDialog: function () {
+    this.setState({showDialog: false});
+  },
+
+  newFile: function () {
+    this.setState(this.getEmptyState());
+  },
+
+  getRemoteUrl: function (filename) {
+    return this.state.username && filename ? ('https://teaching-teamwork.firebaseio.com/dev/activities/' + this.state.username + '/' + filename) : null;
+  },
+
+  componentWillUpdate: function (nextProps, nextState) {
+    var self = this;
+
+    if (nextState.remoteUrl != this.state.remoteUrl) {
+      if (this.remoteUrlWatcher) {
+        this.remoteUrlWatcher.off();
+        this.remoteUrlWatcher = null;
+      }
+      if (nextState.remoteUrl) {
+        this.remoteUrlWatcher = new Firebase(nextState.remoteUrl);
+        this.remoteUrlWatcher.on("value", function (snapshot) {
+          self.setState({published: !!snapshot.val()});
+        });
+      }
+    }
+
+    if (JSON.stringify(nextProps.editorState) != JSON.stringify(this.props.editorState)) {
+      this.setState({
+        filename: nextProps.editorState.filename,
+        remoteUrl: this.getRemoteUrl(nextProps.editorState.filename),
+        via: nextProps.editorState.via,
+        text: nextProps.editorState.text,
+        dirty: false,
+        empty: nextProps.editorState.text.length == 0,
+        opened: false
+      });
+    }
+  },
+
+  openFile: function (localOrRemoteFilename) {
+    var self = this,
+        slashPos = localOrRemoteFilename.indexOf('/'),
+        username = slashPos ? localOrRemoteFilename.substr(0, slashPos) : null,
+        filename = slashPos ? localOrRemoteFilename.substr(slashPos + 1) : null,
+        url = username && filename ? ('https://teaching-teamwork.firebaseio.com/dev/activities/' + username + '/' + filename) : null,
+        firebase = url ? new Firebase(url) : null,
+        text = !firebase ? localStorage.getItem(storagePrefix + localOrRemoteFilename) : null;
+
+    if (text) {
+      this.setState({
+        filename: localOrRemoteFilename,
+        remoteUrl: this.getRemoteUrl(localOrRemoteFilename),
+        via: null,
+        text: text,
+        dirty: false,
+        empty: text.length == 0,
+        opened: true
+      });
+      this.hideDialog();
+    }
+    else if (firebase) {
+      firebase.once('value', function (snapshot) {
+        var jsonData = snapshot.val();
+        if (jsonData) {
+          self.setState({
+            filename: filename,
+            remoteUrl: self.getRemoteUrl(filename),
+            via: 'user ' + username,
+            text: jsonData,
+            dirty: false,
+            empty: jsonData.length == 0,
+            opened: true
+          });
+          self.hideDialog();
+        }
+        else {
+          alert("No data found for REMOTE activity at " + url);
+        }
+      }, function (error) {
+        alert("Could not find REMOTE activity at " + url);
+      });
+    }
+    else {
+      alert('Unable to open ' + filename);
+    }
+  },
+
+  saveFile: function (filename) {
+    localStorage.setItem(storagePrefix + filename, this.state.text);
+    this.setState({
+      filename: filename,
+      dirty: false,
+      remoteUrl: this.getRemoteUrl(filename),
+      via: null
+    });
+    this.hideDialog();
+  },
+
+  deleteFile: function () {
+    localStorage.removeItem(storagePrefix + this.state.filename);
+    this.newFile();
+  },
+
+  useFile: function () {
+    this.props.parseAndStartActivity(this.state.filename || 'New Activity', this.state.text)
+  },
+
+  useRemoteFile: function () {
+    window.open('#remote:' + this.state.username + '/' + this.state.filename);
+  },
+
+  formatText: function () {
+    try {
+      this.setState({text: JSON.stringify(JSON.parse(this.state.text), null, 2)});
+    }
+    catch (e) {
+      alert('Unable to format invalid JSON!');
+    }
+  },
+
+  isValidText: function (message) {
+    try {
+      JSON.parse(this.state.text);
+      return true;
+    }
+    catch (e) {
+      alert(message || 'The JSON is NOT valid');
+      return false;
+    }
+  },
+
+  getAuthClient: function (callback) {
+    var self = this;
+    this.authClient = this.authClient || new FirebaseSimpleLogin(this.firebase, function(error, user) {
+      var atPos = user && user.email ? user.email.indexOf('@') : 0,
+          username = atPos ? user.email.substr(0, atPos) : null;
+      if (error) {
+        alert(error);
+      }
+      self.setState({
+        user: user,
+        username: username,
+        remoteUrl: self.getRemoteUrl(self.state.filename)
+      });
+      if (callback) {
+        callback(error, user);
+      }
+    });
+    return this.authClient;
+  },
+
+  login: function (email, password) {
+    var saveLogin = function (error, user) {
+          if (!error) {
+            localStorage.setItem(loginKey, JSON.stringify({
+              email: email,
+              password: password
+            }));
+          }
+        },
+        
+    email = email || prompt('Email?');
+    password = password || (email ? prompt('Password?') : null);
+
+    if (email && password) {
+      this.getAuthClient(saveLogin).login("password", {
+        email: email,
+        password: password
+      });
+    }
+  },
+
+  logout: function () {
+    if (confirm('Are you sure you want to logout?')) {
+      this.getAuthClient().logout();
+      this.setState({user: null});
+      localStorage.setItem(loginKey, null);
+    }
+  },
+
+  publishFile: function () {
+    this.firebase.child('activities').child(this.state.username).child(this.state.filename).set(this.state.text);
+  },
+
+  getPublishedFiles: function (callback) {
+    this.firebase.child('activities').once('value', function (snapshot) {
+      callback(snapshot ? snapshot.val() : null);
+    });
+  },
+
+  handleToolbar: function (button) {
+    var self = this,
+        showDialog = function () {
+          self.setState({showDialog: self.state.showDialog ? false : button});
+        };
+
+    switch (button) {
+      case 'New':
+        if (this.okIfDirty()) {
+          this.newFile();
+        }
+        break;
+      case 'Open':
+        if (this.state.showDialog || this.okIfDirty()) {
+          showDialog();
+        }
+        break;
+      case 'Save':
+        if (this.isValidText('Sorry, you must fix the JSON errors before you can save.')) {
+          if (this.state.filename) {
+            this.saveFile(this.state.filename);
+          }
+          else {
+            showDialog();
+          }
+        }
+        break;
+      case 'Save As':
+        if (this.isValidText('Sorry, you must fix the JSON errors before you can save.')) {
+          showDialog();
+        }
+        break;
+      case 'Use':
+        this.useFile(true);
+        break;
+      case 'Use Remote':
+        if (this.okIfDirty()) {
+          this.useRemoteFile(false);
+        }
+        break;
+      case 'Delete':
+        if (confirm('Are you sure you want to delete this?')) {
+          this.deleteFile();
+        }
+        break;
+      case 'Format':
+        this.formatText();
+        break;
+      case 'Validate':
+        if (this.isValidText()) {
+          alert('The JSON is valid');
+        }
+        break;
+      case 'Login':
+        this.login();
+        break;
+      case 'Logout':
+        this.logout();
+        break;
+      case 'Publish':
+        if (this.isValidText('Sorry, you must fix the JSON errors before you can publish.') && this.okIfDirty()) {
+          this.publishFile();
+        }
+        break;
+    }
+  },
+
+  editorChanged: function (text) {
+    var empty = text.length == 0;
+    this.setState({
+      empty: empty,
+      dirty: !empty && !this.state.opened && !this.state.newed,
+      text: text,
+      opened: false,
+      newed: false
+    });
+  },
+
+  render: function () {
+    return div({id: 'editor'},
+      Header({
+        filename: this.state.filename,
+        dirty: this.state.dirty,
+        user: this.state.user,
+        username: this.state.username,
+        via: this.state.via,
+        published: this.state.published
+      }),
+      Toolbar({
+        filename: this.state.filename,
+        dirty: this.state.dirty,
+        empty: this.state.empty,
+        user: this.state.user,
+        onButtonPressed: this.handleToolbar,
+        published: this.state.published
+      }),
+      Editor({
+        changed: this.editorChanged,
+        text: this.state.text
+      }),
+      Dialog({
+        show: this.state.showDialog,
+        hideDialog: this.hideDialog,
+        openFile: this.openFile,
+        saveFile: this.saveFile,
+        getPublishedFiles: this.getPublishedFiles
+      })
+    );
+  }
+});
+
+Header = React.createFactory(React.createClass({
+  displayName: 'Header',
+
+  render: function () {
+    var alert = function (type, show, text) {
+      return show ? span({className: 'alert alert-' + type}, text) : null
+    }
+    return div({className: 'header'},
+      'Teaching Teamwork Activity Editor - ',
+      span({}, this.props.filename || italics({}, 'New Activity')),
+      this.props.via ? italics({}, ' (via ', this.props.via, ')') : null,
+      alert('warning', this.props.dirty, 'UNSAVED'),
+      alert('info', this.props.published && !this.props.dirty, 'PUBLISHED'),
+      alert('warning', this.props.published && this.props.dirty, 'CHANGES NOT PUBLISHED'),
+      div({style: {float: 'right'}}, this.props.user ? (this.props.user.email + ' (' + this.props.username + ')') : null)
+    );
+  }
+}));
+
+Toolbar = React.createFactory(React.createClass({
+  displayName: 'Toolbar',
+
+  clicked: function (e) {
+    var button = e.target;
+    if ((button.nodeName != 'SPAN') || (button.className == 'disabled')) {
+      return;
+    }
+    this.props.onButtonPressed(button.innerHTML);
+  },
+
+  render: function () {
+    var disabledProps = {className: 'disabled'},
+        dirtyProps = this.props.dirty ? {} : disabledProps,
+        emptyProps = this.props.empty ? disabledProps : {},
+        deleteProps = this.props.filename === null ? {className: 'disabled'} : {},
+        filenameProps = this.props.filename === null ? {className: 'disabled'} : {};
+
+    return div({className: 'toolbar', onClick: this.clicked},
+      span({}, 'New'),
+      span({}, 'Open'),
+      span(dirtyProps, 'Save'),
+      span(emptyProps, 'Save As'),
+      span(emptyProps, 'Format'),
+      span(emptyProps, 'Validate'),
+      span(filenameProps, 'Use'),
+      this.props.user ? span(filenameProps, 'Publish') : null,
+      this.props.user ? span(this.props.published ? {} : disabledProps, 'Use Remote') : null,
+      span({}, this.props.user ? 'Logout' : 'Login'),
+      span({className: this.props.filename === null ? 'disabled' : null, style: {'float': 'right'}}, 'Delete')
+    );
+  }
+}));
+
+Editor = React.createFactory(React.createClass({
+  displayName: 'Editor',
+
+  componentDidMount: function() {
+    this.editor = CodeMirror.fromTextArea(this.refs.editor.getDOMNode(), {
+      lineNumbers: true,
+      matchBrackets: true,
+      autoCloseBrackets: true,
+      mode: 'application/json',
+      tabSize: 2,
+      electricChars: true,
+      lint: true,
+      gutters: ["CodeMirror-lint-markers"],
+    });
+    this.editor.on('change', this.handleChange);
+  },
+
+  shouldComponentUpdate: function() {
+    return false;
+  },
+
+  componentWillReceiveProps: function (nextProps) {
+    if (this.editor.getValue() != nextProps.text) {
+      this.editor.setValue(nextProps.text);
+    }
+  },
+
+  handleChange: function() {
+    if (!this.editor) {
+      return;
+    }
+    this.props.changed(this.editor.getValue());
+  },
+
+  render: function () {
+    return div({className: 'text'}, React.DOM.textarea({
+      ref: 'editor',
+      defaultValue: this.props.text
+    }));
+  }
+}));
+
+FileListItem = React.createFactory(React.createClass({
+  displayName: 'FileListItem',
+
+  clicked: function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.clicked(this.props.file);
+  },
+
+  render: function () {
+    return div({className: 'filelistitem', onClick: this.clicked}, this.props.file);
+  }
+}));
+
+Dialog = React.createFactory(React.createClass({
+  displayName: 'Dialog',
+
+  getInitialState: function () {
+    this.lastFileClick = null;
+    return {
+      localFiles: [],
+      remoteFiles: []
+    };
+  },
+
+  findFiles: function () {
+    var self = this,
+        localFiles = [],
+        remoteFiles = [],
+        i, len, key;
+    for (i = 0, len = localStorage.length; i < len; ++i ) {
+      key = localStorage.key(i);
+      if (key.substr(0, storagePrefix.length) == storagePrefix) {
+        localFiles.push(key.substr(storagePrefix.length));
+      }
+    }
+    this.setState({
+      localFiles: localFiles,
+      remoteFiles: []
+    });
+
+    this.props.getPublishedFiles(function (publishedFiles) {
+      if (publishedFiles) {
+        for (var username in publishedFiles) {
+          if (publishedFiles.hasOwnProperty(username)) {
+            for (var filename in publishedFiles[username]) {
+              remoteFiles.push(username + '/' + filename);
+            }
+          }
+        }
+        self.setState({remoteFiles: remoteFiles});
+      }
+    });
+  },
+
+  componentWillReceiveProps: function (nextProps) {
+    if (nextProps.show) {
+      var input = this.refs.fileinput.getDOMNode();
+      input.value = '';
+      setTimeout(function () {
+        input.focus();
+      }, 10);
+      this.findFiles();
+    }
+  },
+
+  checkForEnter: function (e) {
+    if (e.which == 13) {
+      this.buttonClicked();
+    }
+  },
+
+  buttonClicked: function () {
+    var filename = this.refs.fileinput.getDOMNode().value.replace(/^\s+|\s+$/g, '');
+    if (filename.length > 0) {
+      switch (this.props.show) {
+        case 'Open':
+          this.props.openFile(filename);
+          break;
+        case 'Save':
+        case 'Save As':
+          this.props.saveFile(filename);
+          break;
+      }
+    }
+  },
+
+  fileClicked: function (filename) {
+    this.refs.fileinput.getDOMNode().value = filename;
+    var now = (new Date()).getTime();
+    if (now - this.lastFileClick < 250) {
+      this.buttonClicked();
+    }
+    this.lastFileClick = now;
+  },
+
+  render: function () {
+    var files = [div({className: 'fileheader', key: 'local-header'}, 'Local Files')],
+        i, len;
+    for (i = 0, len = this.state.localFiles.length; i < len; i++) {
+      files.push(FileListItem({file: this.state.localFiles[i], key: 'local' + i, clicked: this.fileClicked}));
+    }
+    if ((this.props.show == 'Open') && (this.state.remoteFiles.length > 0)) {
+      files.push(div({className: 'fileheader', key: 'remote-header', style: {marginTop: 10}}, 'Remote Files'));
+      for (i = 0, len = this.state.remoteFiles.length; i < len; i++) {
+        files.push(FileListItem({file: this.state.remoteFiles[i], key: 'remote' + i, clicked: this.fileClicked}));
+      }
+    }
+
+    return div({className: 'dialog', style: {'display': this.props.show ? 'block' : 'none'}},
+      div({className: 'title'},
+        this.props.show,
+        div({className: 'close', onClick: this.props.hideDialog}, 'X')
+      ),
+      div({className: 'inner'},
+        div({className: 'filelist', onClick: this.fileClicked}, files),
+        React.DOM.input({className: 'fileinput', type: 'text', ref: 'fileinput', onKeyUp: this.checkForEnter}),
+        React.DOM.button({className: 'button', onClick: this.buttonClicked}, this.props.show)
+      )
+    );
+  }
+}));
+
+

--- a/app/src/views/page.jsx
+++ b/app/src/views/page.jsx
@@ -1,6 +1,7 @@
 var ChatView = require('./chat.jsx'),
     CalculatorView = require('./calculator.jsx'),
     NotesView = require('./notes'),
+    EditorView = require('./editor'),
     config = require('../config');
 
 module.exports = React.createClass({
@@ -11,7 +12,9 @@ module.exports = React.createClass({
     var activity = this.props.activity ? this.props.activity : {},
         activityName = activity.name ? ': ' + activity.name : '',
         circuit = this.props.circuit ? (<h2>Circuit { this.props.circuit }</h2>) : null,
-        notes = this.props.client ? (this.props.client.notes || "") : "";
+        notes = this.props.client ? (this.props.client.notes || "") : "",
+        editor = this.props.showEditor ? (<EditorView parseAndStartActivity={ this.props.parseAndStartActivity } editorState={ this.props.editorState } />) : null,
+        image = activity.image ? (<img src={ /^https?:\/\//.test(activity.image) ? activity.image : config.modelsBase + activity.image } />) : null;
 
     return (
       <div className="tt-page">
@@ -19,9 +22,10 @@ module.exports = React.createClass({
         { circuit }
         <div id="breadboard-wrapper"></div>
         { activity.clients && activity.clients.length > 1 ? (<ChatView {...activity} />) : null }
-        <div id="image-wrapper">{ activity.image ? (<img src={ config.modelsBase + activity.image } />) : null }</div>
+        <div id="image-wrapper">{ image }</div>
         <CalculatorView />
         <div id="notes-wrapper"><NotesView text={ notes } className="tt-notes" breadboard={ this.props.breadboard } /></div>
+        { editor }
       </div>
     );
   }

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,8 @@
   "name": "teaching-teamwork",
   "version": "0.0.1",
   "dependencies": {
-    "breadboard": "0.0.2"
+    "breadboard": "0.0.2",
+    "codemirror": "5.0.0",
+    "jsonlint": "1.6.0"
   }
 }

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -23,7 +23,7 @@ module.exports = {
     dest: dest
   },
   vendor: {
-    src: [bower + '/breadboard/**/*'],
+    src: [bower + '/breadboard/**/*', bower + '/codemirror/**/*', bower + '/jsonlint/**/*'],
     base: bower + '/',
     dest: dest + '/vendor'
   }


### PR DESCRIPTION
Moves the editor into the page, visible when "?editor" is appended to the url like this:

http://dougmartin.github.io/concord/teaching-teamwork/integrate-editor/?editor

_NOTE_: If you want to use a server activity like "two-resistors" you should add the hash after the "?editor" like this:

http://dougmartin.github.io/concord/teaching-teamwork/integrate-editor/?editor#two-resistors

The editor is shown at the bottom of the page and works almost the same as the separate page editor.  The differences are:

1. You don't need to save the file to use it - 'Use Local' has been changed to 'Use' - it will restart the activity using the new data
2. The JSON is saved as a string in Firebase so that the ordering of the file is left in place (when it was stored as an object Firebase returned the keys of the object in alphabetical order).  I had to delete the existing published activities once this was in place.
3. The header now shows either "via server" for activities on the server, "via user (username)" for published activities or "via local" for locally saved activities
