### PR TITLE
Added query string flag of 'no-activity' to skip loading the activity

### DIFF
--- a/app/src/views/app.js
+++ b/app/src/views/app.js
@@ -35,8 +35,10 @@ module.exports = React.createClass({
     // load blank workbench
     sparks.createWorkbench({"circuit": []}, "breadboard-wrapper");
 
-    // load and start activity
-    this.loadActivity(window.location.hash.substring(1) || "two-resistors");
+    // load and start activity if not flagged to skip (for easier debugging)
+    if (!window.location.search.match(/no-activity/)) {
+      this.loadActivity(window.location.hash.substring(1) || "two-resistors");
+    }
   },
 
   loadActivity: function(activityName) {


### PR DESCRIPTION
For easier debugging (by not having to enter your name and group) a query string flag of 'no-activity' can be used.  The code just checks for its presense, not its value like this ?no-activity/