### PR TITLE
Added gulp task to verify activity json files

### DIFF
--- a/activities/test-oscope.json
+++ b/activities/test-oscope.json
@@ -18,7 +18,7 @@
           "amplitude": 16.97,
           "initialFrequency": 1000,
           "connections": "left_positive21,left_negative21"
-        },
+        }
       ]
     },
     {

--- a/gulp/tasks/copy-activities.js
+++ b/gulp/tasks/copy-activities.js
@@ -1,7 +1,11 @@
 var gulp        = require('gulp');
 var config      = require('../config').activities;
+var gulpif      = require('gulp-if');
+var jsonlint    = require("gulp-jsonlint");
 
 gulp.task('copy-activities', function(){
   gulp.src(config.src, { base: config.base })
-    .pipe(gulp.dest(config.dest));
+    .pipe(gulp.dest(config.dest))
+    .pipe(gulpif('*.json', jsonlint()))
+    .pipe(gulpif('*.json', jsonlint.reporter()))
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "karma-browserify": "^3.0.0",
     "reactify": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
-    "event-stream": "^3.3.0"
+    "event-stream": "^3.3.0",
+    "gulp-jsonlint": "^1.0.2",
+    "gulp-if": "^1.2.5"
   },
   "browserify-shim": {
     "external": "global:External"


### PR DESCRIPTION
I decided to add this after changing all those json files - this way we can be sure that at least their syntax is ok.

This uses a combination of two new gulp plugins (gulp-jsonlint and gulp-if) in the copy-activities.js gulp task to narrow the stream to *.json files using gulp-if and to verify the syntax of the json files using gulp-jsonlint.  If there are no errors the output of the gulp run will be the same.  When there are errors the reporter will show the errors in red text.

After running the task I fixed a trailing comma in activities/test-oscope.json

NOTE: once this is merged you will need to run 'npm update' to get the new gulp plugins.