### PR TITLE
Added json-lint gulp task that exits on failure

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -14,6 +14,7 @@ module.exports = {
   },
   activities: {
     src: './activities/**/*',
+    json: './activities/**/*.json',
     base: './',
     dest: dest
   },

--- a/gulp/tasks/copy-activities.js
+++ b/gulp/tasks/copy-activities.js
@@ -1,11 +1,7 @@
 var gulp        = require('gulp');
 var config      = require('../config').activities;
-var gulpif      = require('gulp-if');
-var jsonlint    = require("gulp-jsonlint");
 
 gulp.task('copy-activities', function(){
-  gulp.src(config.src, { base: config.base })
+  return gulp.src(config.src, { base: config.base })
     .pipe(gulp.dest(config.dest))
-    .pipe(gulpif('*.json', jsonlint()))
-    .pipe(gulpif('*.json', jsonlint.reporter()))
 });

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -4,9 +4,10 @@ var config = require('../config');
 gulp.task('watch', function() {
     gulp.watch(config.js.allSrc,  ['browserify']);
     gulp.watch(config.public.src,  ['copy-public']);
+    gulp.watch(config.activities.json, ['json-lint']);
     gulp.watch(config.activities.src, ['copy-activities']);
 });
 
-gulp.task('build-all', ['browserify', 'copy-activities', 'copy-public', 'copy-vendor'])
+gulp.task('build-all', ['browserify', 'copy-activities', 'copy-public', 'copy-vendor', 'json-lint'])
 
 gulp.task('default', ['build-all', 'watch']);

--- a/gulp/tasks/json-lint.js
+++ b/gulp/tasks/json-lint.js
@@ -1,0 +1,26 @@
+var gulp        = require('gulp');
+var config      = require('../config').activities;
+var jsonlint    = require("gulp-jsonlint");
+var es          = require('event-stream');
+var beep        = require('beepbeep');
+
+var exitOnJSONError = function () {
+  return es.map(function (file, cb) {
+    if (file.jsonlint && !file.jsonlint.success) {
+      beep();
+      if (process.env.EXIT_ON_ERRORS) {
+        console.log('Aborting json-lint because of json formatting error(s) (see above for errors)');
+        process.exit(1);
+      }
+    }
+    return cb(null, file);
+  });
+};
+
+gulp.task('json-lint', function(){
+  return gulp.src(config.json, { base: config.base })
+    .pipe(jsonlint())
+    .pipe(jsonlint.reporter())
+    .pipe(exitOnJSONError())
+});
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "./node_modules/gulp/bin/gulp.js",
-    "predeploy": "rm -rf dist && ./node_modules/gulp/bin/gulp.js build-all",
+    "predeploy": "rm -rf dist && EXIT_ON_ERRORS=1 ./node_modules/gulp/bin/gulp.js build-all",
     "deploy": "./deploy.sh gh-pages",
     "test": "cd test; karma start"
   },
@@ -29,7 +29,7 @@
     "vinyl-source-stream": "^1.0.0",
     "event-stream": "^3.3.0",
     "gulp-jsonlint": "^1.0.2",
-    "gulp-if": "^1.2.5"
+    "beepbeep": "^1.2.0"
   },
   "browserify-shim": {
     "external": "global:External"


### PR DESCRIPTION
Moved the json lint check from copy-activities.js into its own gulp task and added an exit on failure so that the predeploy script will abort.