### PR TITLE
Fixed Mathpad dragging bug and hid Mathpad when no activity selected

### DIFF
--- a/app/src/views/mathpad.jsx
+++ b/app/src/views/mathpad.jsx
@@ -131,45 +131,66 @@ module.exports = React.createClass({
   },
 
   startDrag: function (e) {
-    this.dragging = true;
-    this.dragged = false;
-    this.startCalculatorPos = {
-      right: this.state.openRight,
-      top: this.state.openTop,
-    };
-    this.startMousePos = {
-      x: e.clientX,
-      y: e.clientY
-    };
-  },
-
-  drag: function (e) {
-    var newPos;
-    if (this.dragging) {
-      // the calculations are reversed here only because we are setting the right pos and not the left
-      newPos = {
-        openRight: this.startCalculatorPos.right + (this.startMousePos.x - e.clientX),
-        openTop: this.startCalculatorPos.top + (e.clientY - this.startMousePos.y)
-      };
-      if ((newPos.openRight != this.state.openRight) || (newPos.openTop != this.state.openTop)) {
-        this.setState(newPos);
-        this.dragged = true;
+    var self = this,
+      dragging = true,
+      dragged = false,
+      startCalculatorPos = {
+        right: this.state.openRight,
+        top: this.state.openTop,
+      },
+      startMousePos = {
+        x: e.clientX,
+        y: e.clientY
+      },
+      mousemove, mouseup;
+    
+    mousemove = function (e) {
+      var newPos;
+      if (dragging) {
+        // the calculations are reversed here only because we are setting the right pos and not the left
+        newPos = {
+          openRight: startCalculatorPos.right + (startMousePos.x - e.clientX),
+          openTop: startCalculatorPos.top + (e.clientY - startMousePos.y)
+        };
+        if ((newPos.openRight != self.state.openRight) || (newPos.openTop != self.state.openTop)) {
+          self.setState(newPos);
+          dragged = true;
+        }
       }
+    };
+    
+    mouseup = function (e) {
+      if (dragged) {
+        logController.logEvent("MathPad dragged", null, {
+          "startTop": startCalculatorPos.top,
+          "startRight": startCalculatorPos.right,
+          "endTop": self.state.openTop,
+          "endRight": self.state.openRight,
+        });
+        dragged = false;
+      }
+      dragging = false;
+      
+      if (window.removeEventListener) {
+        window.removeEventListener('mousemove', mousemove);
+        window.removeEventListener('mouseup', mouseup);
+      }
+      else {
+        window.detactEvent('onmousemove', mousemove);
+        window.detactEvent('onmouseup', mouseup);
+      }
+      
+      self.focus();
+    };
+    
+    if (window.addEventListener) {
+      window.addEventListener('mousemove', mousemove, false);
+      window.addEventListener('mouseup', mouseup, false);
     }
-  },
-
-  endDrag:  function (e) {
-    if (this.dragged) {
-      logController.logEvent("MathPad dragged", null, {
-        "startTop": this.startCalculatorPos.top,
-        "startRight": this.startCalculatorPos.right,
-        "endTop": this.state.openTop,
-        "endRight": this.state.openRight,
-      });
-      this.dragged = false;
+    else {
+      window.attachEvent('onmousemove', mousemove);
+      window.attachEvent('onmouseup', mouseup);
     }
-    this.dragging = false;
-    this.focus();
   },
 
   open: function (e) {
@@ -209,7 +230,7 @@ module.exports = React.createClass({
 
     if (this.state.open) {
       return <div className='mathpad mathpad-open' style={style}>
-        <div className='title' onMouseDown={this.startDrag} onMouseMove={this.drag} onMouseUp={this.endDrag}>
+        <div className='title' onMouseDown={this.startDrag} >
           MathPad
           <span className='close' onClick={this.close}>X</span>
         </div>

--- a/app/src/views/page.jsx
+++ b/app/src/views/page.jsx
@@ -24,7 +24,7 @@ module.exports = React.createClass({
         <div id="breadboard-wrapper"></div>
         { hasMultipleClients ? (<ChatView {...activity} />) : null }
         <div id="image-wrapper">{ image }</div>
-        <MathPadView />
+        {this.props.activity ? (<MathPadView />) : null }
         <div id="notes-wrapper"><NotesView text={ notes } className="tt-notes" breadboard={ this.props.breadboard } /></div>
         { editor }
       </div>


### PR DESCRIPTION
Moved the mousemove and mouseup handlers off of the div and onto the window so dragging doesn't get stuck if the mouse moves too fast.

Also hid Mathpad when no activity is selected because opening Mathpad logs an event which causes an error because the logger doesn't have the activityName variable set.