### PR TITLE
Gulp check if the required bower components exist and are the correct version

### DIFF
--- a/gulp/tasks/bower-check.js
+++ b/gulp/tasks/bower-check.js
@@ -1,0 +1,44 @@
+// checks if the required bower components exist and are the correct version
+
+var gulp   = require('gulp');
+var fs     = require('fs');
+var path   = require('path');
+var beep   = require('beepbeep');
+
+var error = function (message) {
+  beep();
+  console.error(message);
+  if (process.env.EXIT_ON_ERRORS) {
+    process.exit(1);
+  }
+};
+
+gulp.task('bower-check', function() {
+  var rootPath = path.resolve(__dirname, '../../'),
+      getPath = function (to) {
+        return path.resolve(rootPath, to);
+      },
+      bower = require(getPath('bower.json')),
+      component;
+      
+  for (component in bower.dependencies) {
+    (function (component) {
+      // note: we are loading the dotfile which is maintained by bower with the currently installed package
+      var componentPackagePath = getPath('bower_components/' + component + '/.bower.json'),
+          componentPackage;
+          
+      fs.exists(componentPackagePath, function (exists) {
+        if (exists) {
+          componentPackage = require(componentPackagePath);
+          if (componentPackage.version != bower.dependencies[component]) {
+            error('Please run "bower update".  The ' + component + ' bower component installed version number (' +  componentPackage.version + ') does not match the required version number (' + bower.dependencies[component] + ')');
+          }
+        }
+        else {
+          error('Please run "bower install".  The ' + component + ' bower component is not installed!');
+        }
+      });
+    })(component);
+  }
+});
+

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -8,6 +8,6 @@ gulp.task('watch', function() {
     gulp.watch(config.activities.src, ['copy-activities']);
 });
 
-gulp.task('build-all', ['browserify', 'copy-activities', 'copy-public', 'copy-vendor', 'json-lint'])
+gulp.task('build-all', ['browserify', 'copy-activities', 'copy-public', 'copy-vendor', 'json-lint', 'bower-check'])
 
 gulp.task('default', ['build-all', 'watch']);


### PR DESCRIPTION
This is just an insurance policy against deploying the incorrect vendor files.

Like the json-lint check this will exit if the EXIT_ON_ERRORS environment variable is set.

