### PR TITLE
Don't show all the goals in the submit popup [#97386506]

### DIFF
--- a/app/src/views/submitButton.js
+++ b/app/src/views/submitButton.js
@@ -186,7 +186,7 @@ module.exports = SubmitButton = React.createClass({
             goalValue: absGoalValue + units,
             currentValue: absClientGoalValue + units
           });
-          
+
           logParams[item.name + ': Goal'] = absGoalValue;
           logParams[item.name + ': Measured'] = absClientGoalValue;
 
@@ -232,7 +232,7 @@ module.exports = SubmitButton = React.createClass({
 
   popupButtonClicked: function () {
     logController.logEvent("Submit close button clicked", this.state.allCorrect ? 'done' : 'resume');
-    
+
     if (this.state.allCorrect) {
       window.location = 'http://concord.org/projects/teaching-teamwork/activities2';
     }
@@ -333,7 +333,7 @@ Popup = React.createFactory(React.createClass({
 
     return React.DOM.div({className: 'submit-button-popup'},
       React.DOM.h1({}, title),
-      React.DOM.table({}, React.DOM.tbody({}, circuitRows)),
+      (this.props.allCorrect ? React.DOM.table({}, React.DOM.tbody({}, circuitRows)) : React.DOM.p({}, "At least one of your team's voltage drops doesn't match that player's goal. Try again.")),
       React.DOM.button({onClick: this.props.buttonClicked}, label)
     );
   }


### PR DESCRIPTION
This removes the page and adds the following text if all the goals are not correct: "At least one of your team's voltage drops doesn't match that player's goal. Try again.".  If all the goals are met then the table is shown -- I thought that would make for a nice final review of the activity.