### PR TITLE
Log dmm values and update activity json notes with units

### DIFF
--- a/activities/three-resistors-level1.json
+++ b/activities/three-resistors-level1.json
@@ -92,7 +92,7 @@
     {
       "show_multimeter": true,
       "showComponentEditor": true,
-      "notes": "Level 1: E = $E, R = 0, your goal is to make your voltage $V1 volts.",
+      "notes": "Level 1: E = $E volts, R = 0 Ω, your goal is to make your voltage $V1 volts.",
       "circuit": [
         {
           "type": "wire",

--- a/activities/three-resistors-level1.json
+++ b/activities/three-resistors-level1.json
@@ -33,7 +33,7 @@
         "tolerance": 0.005
       }
     }
-  ],   
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -57,18 +57,34 @@
       "hidden": true
     }
   ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "0"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "0"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-level2.json
+++ b/activities/three-resistors-level2.json
@@ -33,7 +33,7 @@
         "tolerance": 0.005
       }
     }
-  ],  
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -64,18 +64,34 @@
       "hidden": true
     }
   ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-level2.json
+++ b/activities/three-resistors-level2.json
@@ -99,7 +99,7 @@
     {
       "show_multimeter": true,
       "showComponentEditor": true,
-      "notes": "Level 2: E = $E, R = $R, your goal is to make your voltage $V1 volts.",
+      "notes": "Level 2: E = $E volts, R = $R Ω, your goal is to make your voltage $V1 volts.",
       "circuit": [
         {
           "type": "wire",

--- a/activities/three-resistors-level3.json
+++ b/activities/three-resistors-level3.json
@@ -33,7 +33,7 @@
         "tolerance": 0.005
       }
     }
-  ],    
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -64,18 +64,34 @@
       "hidden": true
     }
   ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-level3.json
+++ b/activities/three-resistors-level3.json
@@ -99,7 +99,7 @@
     {
       "show_multimeter": true,
       "showComponentEditor": true,
-      "notes": "Level 3: E = $E, R = $R, your goal is to make your voltage $V1 volts.",
+      "notes": "Level 3: E = $E volts, R = $R Ω, your goal is to make your voltage $V1 volts.",
       "circuit": [
         {
           "type": "wire",

--- a/activities/three-resistors-level4.json
+++ b/activities/three-resistors-level4.json
@@ -99,7 +99,7 @@
     {
       "show_multimeter": true,
       "showComponentEditor": true,
-      "notes": "Level 4: E is unknown, R = $R, your goal is to make your voltage $V1 volts.",
+      "notes": "Level 4: E is unknown, R = $R Ω, your goal is to make your voltage $V1 volts.",
       "circuit": [
         {
           "type": "wire",

--- a/activities/three-resistors-level4.json
+++ b/activities/three-resistors-level4.json
@@ -33,7 +33,7 @@
         "tolerance": 0.005
       }
     }
-  ],    
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -64,18 +64,34 @@
       "hidden": true
     }
   ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-level5.json
+++ b/activities/three-resistors-level5.json
@@ -32,7 +32,7 @@
         "tolerance": 0.005
       }
     }
-  ],    
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -63,18 +63,34 @@
       "hidden": true
     }
   ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-solo-level1.json
+++ b/activities/three-resistors-solo-level1.json
@@ -79,7 +79,7 @@
       "showComponentEditor": true,
       "showComponentDrawer": false,
       "show_multimeter": true,
-      "notes": "Level 1: E = $E, R = 0, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
+      "notes": "Level 1: E = $E volts, R = 0 Ω, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
       "circuit": [
         {
           "type": "resistor",

--- a/activities/three-resistors-solo-level1.json
+++ b/activities/three-resistors-solo-level1.json
@@ -29,7 +29,7 @@
         "tolerance": 0.005
       }
     }
-  ],    
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -43,18 +43,34 @@
       "hidden": true
     }
    ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "0"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "0"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-solo-level2.json
+++ b/activities/three-resistors-solo-level2.json
@@ -86,7 +86,7 @@
       "showComponentEditor": true,
       "showComponentDrawer": false,
       "show_multimeter": true,
-      "notes": "Level 2: E = $E, R = $R, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
+      "notes": "Level 2: E = $E volts, R = $R Ω, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
       "circuit": [
         {
           "type": "resistor",

--- a/activities/three-resistors-solo-level2.json
+++ b/activities/three-resistors-solo-level2.json
@@ -29,7 +29,7 @@
         "tolerance": 0.005
       }
     }
-  ], 
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -50,18 +50,34 @@
       "hidden": true
     }
    ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-solo-level3.json
+++ b/activities/three-resistors-solo-level3.json
@@ -86,7 +86,7 @@
       "showComponentEditor": true,
       "showComponentDrawer": false,
       "show_multimeter": true,
-      "notes": "Level 3: E = $E, R = $R, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
+      "notes": "Level 3: E = $E volts, R = $R Ω, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
       "circuit": [
         {
           "type": "resistor",

--- a/activities/three-resistors-solo-level3.json
+++ b/activities/three-resistors-solo-level3.json
@@ -29,7 +29,7 @@
         "tolerance": 0.005
       }
     }
-  ], 
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -50,18 +50,34 @@
       "hidden": true
     }
    ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-solo-level4.json
+++ b/activities/three-resistors-solo-level4.json
@@ -86,7 +86,7 @@
       "showComponentEditor": true,
       "showComponentDrawer": false,
       "show_multimeter": true,
-      "notes": "Level 4: E is unknown, R = $R, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
+      "notes": "Level 4: E is unknown, R = $R Ω, your goal is to make V1 = $V1 volts, V2 = $V2 volts, and V3 = $V3 volts.",
       "circuit": [
         {
           "type": "resistor",

--- a/activities/three-resistors-solo-level4.json
+++ b/activities/three-resistors-solo-level4.json
@@ -29,7 +29,7 @@
         "tolerance": 0.005
       }
     }
-  ], 
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -50,18 +50,34 @@
       "hidden": true
     }
    ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/activities/three-resistors-solo-level5.json
+++ b/activities/three-resistors-solo-level5.json
@@ -28,7 +28,7 @@
         "tolerance": 0.005
       }
     }
-  ], 
+  ],
   "externalComponents": [
     {
       "type": "battery",
@@ -49,18 +49,34 @@
       "hidden": true
     }
    ],
-  "logEvent": {
-    "Activity Settings": {
-      "parameters": {
-        "E": "$E",
-        "R0": "$R"
+  "logging": {
+    "startActivity": {
+      "Activity Settings": {
+        "parameters": {
+          "E": "$E",
+          "R0": "$R"
+        }
+      },
+      "Activity Goals": {
+        "parameters": {
+          "V1": "$V1",
+          "V2": "$V2",
+          "V3": "$V3"
+        }
       }
     },
-    "Activity Goals": {
-      "parameters": {
-        "V1": "$V1",
-        "V2": "$V2",
-        "V3": "$V3"
+    "append": {
+      "local": {
+        "components": [
+          {"name": "r1", "measurement": "resistance"},
+          {"name": "r2", "measurement": "resistance"},
+          {"name": "r3", "measurement": "resistance"}
+        ]
+      },
+      "remote": {
+        "events": {
+          "sparks": ["DMM measurement"]
+        }
       }
     }
   },

--- a/app/src/controllers/events.js
+++ b/app/src/controllers/events.js
@@ -1,0 +1,112 @@
+var userController = require('./user');
+
+var EventsController = function() {
+};
+
+EventsController.prototype = {
+
+  init: function(options) {
+    var self = this,
+        i, j;
+
+    this.options = options;
+
+    this.myEventValues = {sparks: {}};
+    this.remoteEventValues = {};
+
+    // setup the remote sparks event object for ourself and for each client
+    this.remoteSparksEvents = this.options.logging && this.options.logging.append && this.options.logging.append.remote && this.options.logging.append.remote.events && this.options.logging.append.remote.events.sparks ? this.options.logging.append.remote.events.sparks : [];
+    for (i=0; i < this.options.numClients; i++) {
+      this.remoteEventValues[i] = {sparks: {}};
+      for (j=0; j < this.remoteSparksEvents.length; j++) {
+        this.myEventValues.sparks[this.remoteSparksEvents[j]] = null;
+        this.remoteEventValues[i].sparks[this.remoteSparksEvents[j]] = null;
+      }
+    }
+
+    this.remoteEventsFirebaseRef = userController.getFirebaseGroupRef().child('events');
+
+    // track all remote event changes so we can append then to the log
+    this.remoteEventsFirebaseRef.on("value", function(snapshot) {
+      var snapshotValues = snapshot.val(),
+          clientIndex, eventType, eventName, events;
+
+      if (!snapshotValues) {
+        return;
+      }
+
+      // merge the snapshot values into the saved remote values
+      for (clientIndex=0; clientIndex < self.options.numClients; clientIndex++) {
+        if (snapshotValues[clientIndex]) {
+          for (eventType in self.remoteEventValues[clientIndex]) {
+            if (self.remoteEventValues[clientIndex].hasOwnProperty(eventType) && snapshotValues[clientIndex].hasOwnProperty(eventType)) {
+              events = self.remoteEventValues[clientIndex][eventType];
+              for (eventName in events) {
+                if (events.hasOwnProperty(eventName)) {
+                  events[eventName] = snapshotValues[clientIndex][eventType].hasOwnProperty(eventName) ? snapshotValues[clientIndex][eventType][eventName] : null;
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    this.myRemoteEventsFirebaseRef = this.remoteEventsFirebaseRef.child(options.clientNumber);
+    this.myRemoteEventsFirebaseRef.set(this.myEventValues);
+  },
+
+  handleLocalSparksEvent: function(event) {
+    // check if event is one we need to replicate in FB
+    if (this.remoteSparksEvents.indexOf(event.name) !== -1) {
+      this.myEventValues.sparks[event.name] = event.value;
+      this.myRemoteEventsFirebaseRef.set(this.myEventValues);
+    }
+  },
+
+  appendRemoteEventValues: function(data) {
+    var clientIndex, key, eventType, eventName, events;
+
+    if (!this.options) {
+      return;
+    }
+
+    // append each remote event value to the log
+    for (clientIndex=0; clientIndex < this.options.numClients; clientIndex++) {
+      if (this.remoteEventValues[clientIndex]) {
+        for (eventType in this.remoteEventValues[clientIndex]) {
+          if (this.remoteEventValues[clientIndex].hasOwnProperty(eventType)) {
+            events = this.remoteEventValues[clientIndex][eventType];
+            for (eventName in events) {
+              if (events.hasOwnProperty(eventName)) {
+                key = ['circuit ' + (clientIndex + 1), eventType, eventName].join(':');
+                this._appendObjectValues(data, key, this.remoteEventValues[clientIndex][eventType][eventName]);
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  _appendObjectValues: function(data, key, objectOrValue) {
+    var childKey;
+
+    if ($.isPlainObject(objectOrValue)) {
+      for (childKey in objectOrValue) {
+        if (objectOrValue.hasOwnProperty(childKey)) {
+          this._appendObjectValues(data, [key, childKey].join(':'), objectOrValue[childKey]);
+        }
+      }
+    }
+    else {
+      // remove spaces if otherwise a numeric answer - the DMM uses spaces to separate the 7-segment display values
+      if (/^[\d\s\.]+$/.test(objectOrValue)) {
+        objectOrValue = objectOrValue.replace(/\s/g, '');
+      }
+      data[key] = objectOrValue;
+    }
+  }
+};
+
+module.exports = new EventsController();

--- a/app/src/data/workbenchFBConnector.js
+++ b/app/src/data/workbenchFBConnector.js
@@ -1,15 +1,16 @@
-var clientListFirebaseRef,
+var eventsController = require('../controllers/events'),
+    clientListFirebaseRef,
     myCircuitFirebaseRef,
     clientNumber,
     wa,
     userController;
 
 function init() {
-
   sparks.logController.addListener(function(evt) {
     if (evt.name == "Changed circuit") {
       myCircuitFirebaseRef.set(wa.getClientCircuit());
     }
+    eventsController.handleLocalSparksEvent(evt);
   });
 
   // scratch
@@ -25,7 +26,6 @@ function addClientListener(client) {
     wa.updateClient(client, snapshot.val());
   });
 }
-
 
 function WorkbenchFBConnector(_userController, _clientNumber, _wa) {
   if (!_userController.getFirebaseGroupRef()) {

--- a/app/src/views/sidebar-chat.jsx
+++ b/app/src/views/sidebar-chat.jsx
@@ -40,7 +40,7 @@ module.exports = React.createClass({
     input.focus();
     logController.logEvent("Sent message", message);
   },
-  
+
   listenForEnter: function (e) {
     if (e.keyCode === 13) {
       this.handleSubmit(e);
@@ -67,7 +67,6 @@ ChatItems = React.createClass({
   displayName: 'ChatItems',
 
   componentDidUpdate: function (prevProps) {
-    console.log('componentDidUpdate ' + prevProps.items.length + ' / ' + this.props.items.length);
     if (prevProps.items.length !== this.props.items.length) {
       var items = this.refs.items ? this.refs.items.getDOMNode() : null;
       if (items) {


### PR DESCRIPTION
This changes the activity log json files to add a logging config.  The logging config merges the existing logEvents config, exposes a config setting to log component values (previously this was baked into the code) and adds a config setting to log sparks event values with the only value currently being logged being the DMM measurement.  Both the component and event values are included in every log post.

I also updated the client notes activity json files to include units.  This was a different story but it touched the same files.