### PR TITLE
Skip username and group dialogs if cookie is set [#97655728]

### DIFF
--- a/app/src/controllers/user.js
+++ b/app/src/controllers/user.js
@@ -1,5 +1,6 @@
 var UserRegistrationView = require('../views/userRegistration.jsx'),
     logController = require('./log'),
+    userController,
     numClients,
     activityName,
     userName,
@@ -50,13 +51,19 @@ offsetRef.on("value", function(snap) {
   serverSkew = snap.val();
 });
 
-module.exports = {
+module.exports = userController = {
 
   init: function(_numClients, _activityName, _callback) {
     numClients = _numClients;
     activityName = _activityName;
     callback = _callback;
-    UserRegistrationView.open(this, {form: "username"});
+    userName = $.trim($.cookie('userName') || '');
+    if (userName.length === 0) {
+      UserRegistrationView.open(this, {form: "username"});
+    }
+    else {
+      userController.setName(userName);
+    }
   },
 
   setName: function(name) {
@@ -64,7 +71,13 @@ module.exports = {
     $.cookie('userName', name);
     logController.setUserName(userName);
     if (numClients > 1) {
-      UserRegistrationView.open(this, {form: "groupname"});
+      groupName = $.trim($.cookie('groupName') || '');
+      if (groupName.length === 0) {
+        UserRegistrationView.open(this, {form: "groupname"});
+      }
+      else {
+        userController.checkGroupName(groupName);
+      }
     } else {
       UserRegistrationView.close();
       callback(0);

--- a/app/src/views/userRegistration.jsx
+++ b/app/src/views/userRegistration.jsx
@@ -30,17 +30,13 @@ module.exports = window.UserRegistrationView = UserRegistrationView = React.crea
     }
   },
   getInitialState: function() {
-    var userName = $.trim($.cookie('userName') || '');
     return {
-      disableUserName: userName.length > 0,
-      userName: userName,
-      groupName: $.cookie('groupName') || ''
+      userName: $.trim($.cookie('userName') || ''),
+      groupName: $.trim($.cookie('groupName') || '')
     };
   },
   handleUserNameChange: function(event) {
-    if (!this.state.disableUserName) {
-      this.setState({userName: event.target.value});
-    }
+    this.setState({userName: event.target.value});
   },
   handleGroupNameChange: function(event) {
     this.setState({groupName: event.target.value});


### PR DESCRIPTION
This removes the just added functionality of making the username dialog readonly if the cookie is set and instead skips the dialog if the cookie is set.  The group dialog is also skipped if set but the group confirm dialog is still shown so that groups can switch.