### PR TITLE
Fix comment typo in displayed PIC code [#126224121]

### DIFF
--- a/app/src/data/pic/pic-code.js
+++ b/app/src/data/pic/pic-code.js
@@ -450,7 +450,7 @@ code.push({
       "Start        movlw   0x80        ;all bits as outputs but bit7",
       "     tris    PORTB",
       "     ",
-      "     movlw   0xff        ;setup PORTB all inputs",
+      "     movlw   0xff        ;setup PORTA all inputs",
       "     tris    PORTA",
       ";=========================================================================",
       "",


### PR DESCRIPTION
The diff is bad because of change from CRLF to LF.  The actual change is on line 453.