### PR TITLE
Moved sidebar chat div in front of breadboard div [#126550023]

### DIFF
--- a/app/public/css/tt.css
+++ b/app/public/css/tt.css
@@ -491,6 +491,7 @@ form button:disabled {
 }
 .sidebar-chat .sidebar-chat-input {
   padding: 10px;
+  background-color: #fff;
 }
 .sidebar-chat .sidebar-chat-input textarea {
   width: 170px;

--- a/app/src/views/breadboard/page.jsx
+++ b/app/src/views/breadboard/page.jsx
@@ -42,8 +42,8 @@ module.exports = React.createClass({
         </div>
         <div id="notes-wrapper" className={ wrapperClass }><NotesView text={ notes } className="tt-notes" breadboard={ this.props.breadboard } /></div>
         <div id="breadboard-and-chat-wrapper" className={ wrapperClass }>
-          { hasMultipleClients ? (React.DOM.div({id: "sidebar-chat-wrapper", className: wrapperClass}, SidebarChatViewFactory(chatProps))) : null }
           <div id="breadboard-wrapper" className={ wrapperClass }></div>
+          { hasMultipleClients ? (React.DOM.div({id: "sidebar-chat-wrapper", className: wrapperClass}, SidebarChatViewFactory(chatProps))) : null }
         </div>
         { image }
         { calculator }


### PR DESCRIPTION
There was an invisible div in the breadboard that overlayed the left side of the sidebar chat textarea causing it not to be able to be selected by the mouse.