### PR TITLE
Add demo control area to logic gate activity

### DIFF
--- a/activities/logic-gates/adder.json
+++ b/activities/logic-gates/adder.json
@@ -11,14 +11,107 @@
           "7411": {"max": 3},
           "7408": {"max": 3}
         }
+      },
+      "demo": {
+        "chips": {
+          "not": {
+            "type": "7404",
+            "x": 150,
+            "y": 70
+          },
+          "3and1": {
+            "type": "7411",
+            "x": 415,
+            "y": 70
+          },
+          "3and2": {
+            "type": "7411",
+            "x": 150,
+            "y": 220
+          },
+          "2and": {
+            "type": "7408",
+            "x": 415,
+            "y": 220
+          }
+        },
+        "wires": [
+          "in:1,not:13",   "// create NOT A on not pin 12",
+          "in:2,not:11",   "// create NOT A on not pin 12",
+          "in:3,not:9",   "// create NOT A on not pin 12",
+
+          "in:1,3and1:13",  "// A to 3 and input",
+          "not:10,3and1:1", "// NOT B to 3 and input",
+          "not:8,3and1:2",  "// NOT C to 3 and input",
+          "3and1:12,out:1",  "// (A AND NOT B AND NOT C) to output",
+
+          "not:12,3and1:11",  "// NOT A to 3 and input",
+          "in:2,3and1:10", "// B to 3 and input",
+          "not:8,3and1:9",  "// NOT C to 3 and input",
+          "3and1:8,out:2",  "// (NOT A AND B AND NOT C) to output",
+
+          "not:12,3and1:3",  "// NOT A to 3 and input",
+          "not:10,3and1:4", "// NOT B to 3 and input",
+          "in:3,3and1:5",  "// C to 3 and input",
+          "3and1:6,out:3",  "// (NOT A AND B AND C) to output",
+
+          "in:1,3and2:11",  "// A to 3 and input",
+          "in:2,3and2:10", "// B to 3 and input",
+          "in:3,3and2:9",  "// C to 3 and input",
+          "3and2:8,out:4",  "// (A AND B AND C) to output",
+
+          "in:1,2and:13",  "// A to 2 and input",
+          "in:2,2and:12", "// B to 2 and input",
+          "2and:11,out:5", "// (A AND B) to output",
+
+          "in:2,2and:10",  "// B to 2 and input",
+          "in:3,2and:9", "// C to 2 and input",
+          "2and:8,out:6", "// (B AND C) to output",
+
+          "in:1,2and:1",  "// A to 2 and input",
+          "in:3,2and:2", "// C to 2 and input",
+          "2and:3,out:7", "// (A AND C) to output"
+        ]
       }
     },
     {
       "logicChipDrawer": {
         "chips": {
-          "7432": {"max": 5},
-          "7486": {"max": 5}
+          "7432": {"max": 5}
         }
+      },
+      "demo": {
+        "chips": {
+          "or1": {
+            "type": "7432",
+            "x": 150,
+            "y": 135
+          },
+          "or2": {
+            "type": "7432",
+            "x": 415,
+            "y": 135
+          }
+        },
+        "wires": [
+          "in:1,or1:13",   "// (A AND NOT B AND NOT C) to or input",
+          "in:2,or1:12",   "// (NOT A AND B AND NOT C) to or input",
+          "or1:11,or2:13",   "// ((A AND NOT B AND NOT C) OR (NOT A AND B AND NOT C)) to sum or input",
+
+          "in:3,or1:10",   "// (NOT A AND B AND C) to or input",
+          "in:4,or1:9",   "// (A AND B AND C) to or input",
+          "or1:8,or2:12",   "// ((NOT A AND B AND C) OR (A AND B AND C)) to sum or input",
+
+          "in:5,or1:1",   "// (A AND B) to or input",
+          "in:6,or1:2",   "// (B AND C) to or input",
+          "or1:3,or2:1",   "// ((A AND B) OR (B AND C)) to carry or input",
+
+          "in:7,or2:2",   "// (A AND C) to carry or input",
+
+          "or2:11,out:1",   "// (((A AND NOT B AND NOT C) OR (NOT A AND B AND NOT C)) OR ((NOT A AND B AND C) OR (A AND B AND C))) to sum output",
+
+          "or2:3,out:2",   "// (((A AND B) OR (B AND C)) OR (A AND C)) to carry output"
+        ]
       }
     }
   ],

--- a/activities/logic-gates/single-xor.json
+++ b/activities/logic-gates/single-xor.json
@@ -10,6 +10,30 @@
           "7408": {"max": 2},
           "7404": {"max": 3}
         }
+      },
+      "demo": {
+        "chips": {
+          "not": {
+            "type": "7404",
+            "x": 150,
+            "y": 150
+          },
+          "and": {
+            "type": "7408",
+            "x": 425,
+            "y": 150
+          }
+        },
+        "wires": [
+          "in:1,not:13",   "// create NOT A on not pin 12",
+          "in:2,not:9",    "// create NOT B on not pin 8",
+          "not:12,and:13", "// NOT A to and pin 13",
+          "in:2,and:12",   "// B to and pin 12",
+          "and:11,out:1",  "// (NOT A AND B) to output hole 1",
+          "not:8,and:10",  "// NOT B to and pin 10",
+          "in:1,and:9",    "// A to and pin 9",
+          "and:8,out:2",   "// (NOT B AND A) to output hole 2"
+        ]
       }
     },
     {
@@ -17,6 +41,20 @@
         "chips": {
           "7432": {"max": 2}
         }
+      },
+      "demo": {
+        "chips": {
+          "or": {
+            "type": "7432",
+            "x": 300,
+            "y": 150
+          }
+        },
+        "wires": [
+          "in:1,or:13",  "// C = (NOT A AND B) from input hole 1",
+          "in:2,or:12",  "// D = (NOT B AND A) from input hole 2",
+          "or:11,out:1", "// (C OR D) to output hole 1"
+        ]
       }
     }
   ],

--- a/app/src/controllers/pic/board-watcher.js
+++ b/app/src/controllers/pic/board-watcher.js
@@ -29,8 +29,10 @@ BoardWatcher.prototype.pushedButton = function (board, buttonValue) {
   this.firebase.child(board.number).child('button').set(buttonValue);
 };
 BoardWatcher.prototype.circuitChanged = function (board) {
-  this.firebase.child(board.number).child('wires').set(board.serializeWiresToArray());
-  this.firebase.child(board.number).child('components').set(board.serializeComponents());
+  this.firebase.child(board.number).child('layout').set({
+    wires: board.serializeWiresToArray(),
+    components: board.serializeComponents()
+  });
 };
 BoardWatcher.prototype.addListener = function (board, listener) {
   this.listeners[board.number] = this.listeners[board.number] || [];

--- a/app/src/models/shared/board.js
+++ b/app/src/models/shared/board.js
@@ -48,6 +48,8 @@ Board.prototype.clear = function () {
   var i;
   this.wires = [];
   this.circuits = [];
+  this.components = {};
+  this.updateComponentList();
   this.reset();
   for (i = 0; i < this.pinsAndHoles.length; i++) {
     this.pinsAndHoles[i].connected = false;
@@ -347,7 +349,7 @@ Board.prototype.updateComponents = function (newSerializedComponents) {
     var component;
 
     if (serializeComponent.type == 'logic-chip') {
-      component = new LogicChip({type: serializeComponent.chipType, layout: {x: serializeComponent.x, y: serializeComponent.y, width: 150, height: 75}});
+      component = new LogicChip({type: serializeComponent.chipType, layout: {x: serializeComponent.x, y: serializeComponent.y}});
       self.addComponent(name, component);
     }
   });

--- a/app/src/models/shared/hole.js
+++ b/app/src/models/shared/hole.js
@@ -41,8 +41,8 @@ Hole.prototype.reset = function () {
   this.voltage = this.startingVoltage;
   this.pulseProbeDuration = 0;
 };
-Hole.prototype.getColor = function () {
-  return this.color;
+Hole.prototype.getColor = function (editableInput) {
+  return editableInput ? TTL.getColor(this.voltage) : this.color;
 };
 
 module.exports = Hole;

--- a/app/src/views/logic-gates/demo-control.js
+++ b/app/src/views/logic-gates/demo-control.js
@@ -8,11 +8,16 @@ module.exports = React.createClass({
     this.props.toggleAllChipsAndWires();
   },
 
+  toggleDebugPins: function () {
+    this.props.toggleDebugPins();
+  },
+
   render: function () {
     return div({id: 'demo-control'},
       div({id: 'demo-control-title'}, 'Demo Control'),
       div({id: 'demo-control-area'},
-        button({onClick: this.toggleAllChipsAndWires}, (this.props.addedAllChipsAndWires ? '-' : '+') + ' Wires')
+        this.props.hasDemoData ? button({onClick: this.toggleAllChipsAndWires}, (this.props.toggledAllChipsAndWires ? '-' : '+') + ' Chips/Wires') : null,
+        button({onClick: this.toggleDebugPins}, (this.props.showDebugPins ? '-' : '+') + ' Pin Colors')
       )
     );
   }

--- a/app/src/views/logic-gates/logic-chip.js
+++ b/app/src/views/logic-gates/logic-chip.js
@@ -20,11 +20,6 @@ module.exports = React.createClass({
         y: pos.y
       };
     }
-    // TODO: fix me - the width and height are not set when the chip is dragged to the board
-    if (!this.props.component.position.width) {
-      this.props.component.position.width = this.props.component.layout.width;
-      this.props.component.position.height = this.props.component.layout.height;
-    }
     if (this.props.startDragPos) {
       this.startDrag(this.props.startDragPos);
     }
@@ -71,33 +66,7 @@ module.exports = React.createClass({
   layout: function () {
     var label = this.props.component.label,
         selectedConstants = constants.selectedConstants(this.props.selected),
-        position = this.props.component.position,
-        pinDX, pinDY, i, j, pin, pinNumber, xOffset, y;
-
-    pinDX = (position.width - (selectedConstants.PIN_WIDTH * 7)) / 8;
-
-    for (i = 0; i < 2; i++) {
-      y = i === 0 ? position.y + position.height : position.y - selectedConstants.PIN_HEIGHT;
-      pinDY = i === 0 ? -(selectedConstants.PIN_HEIGHT / 2) : 2 * selectedConstants.PIN_HEIGHT;
-
-      for (j = 0; j < 7; j++) {
-        pinNumber = (i * 7) + j;
-        pin = this.props.component.pins[pinNumber];
-        xOffset = i === 0 ? j : 6 - j;
-
-        pin.x = position.x + pinDX + (xOffset * (selectedConstants.PIN_WIDTH + pinDX));
-        pin.y = y;
-
-        pin.cx = pin.x + (selectedConstants.PIN_WIDTH / 2);
-        pin.cy = pin.y + (selectedConstants.PIN_HEIGHT / 2);
-        pin.width = selectedConstants.PIN_WIDTH;
-        pin.height = selectedConstants.PIN_HEIGHT;
-        pin.labelSize = selectedConstants.PIC_FONT_SIZE;
-        pin.label.x = pin.x + (selectedConstants.PIN_WIDTH / 2);
-        pin.label.y = pin.y + pinDY;
-        pin.label.anchor = 'middle';
-      }
-    }
+        position = this.props.component.position;
 
     label.x = position.x + (position.width / 2);
     label.y = position.y + (position.height / 2) + (selectedConstants.CHIP_LABEL_SIZE / 4);

--- a/app/src/views/logic-gates/workspace.js
+++ b/app/src/views/logic-gates/workspace.js
@@ -46,7 +46,8 @@ module.exports = React.createClass({
       return div({id: 'workspace', style: {width: this.props.constants.WORKSPACE_WIDTH, top: (this.props.constants.WORKSPACE_HEIGHT - selectedConstants.BOARD_HEIGHT) / 2}},
         RibbonView({
           constants: this.props.constants,
-          connector: this.state.selectedBoard.connectors.input
+          connector: this.state.selectedBoard.connectors.input,
+          selected: true
         }),
         BoardView({
           constants: this.props.constants,
@@ -57,11 +58,14 @@ module.exports = React.createClass({
           logicChipDrawer: this.props.activity ? this.props.activity.boards[this.props.userBoardNumber].logicChipDrawer : null,
           toggleBoard: this.props.userBoardNumber === this.state.selectedBoard.number ? this.toggleBoard : null,
           toggleBoardButtonStyle: {marginTop: -35},
-          showProbe: true
+          showProbe: true,
+          showDebugPins: this.props.showDebugPins,
+          stepping: true
         }),
         RibbonView({
           constants: this.props.constants,
-          connector: this.state.selectedBoard.connectors.output
+          connector: this.state.selectedBoard.connectors.output,
+          selected: true
         })
       );
     }
@@ -77,7 +81,9 @@ module.exports = React.createClass({
           editable: this.props.userBoardNumber === 0,
           user: this.props.users[0],
           logicChipDrawer: this.props.activity ? this.props.activity.boards[0].logicChipDrawer : null,
-          toggleBoard: this.props.userBoardNumber === 0 ? this.toggleBoard : null
+          toggleBoard: this.props.userBoardNumber === 0 ? this.toggleBoard : null,
+          showDebugPins: this.props.showDebugPins,
+          stepping: true
         }),
         RibbonView({
           constants: this.props.constants,
@@ -89,7 +95,9 @@ module.exports = React.createClass({
           editable: this.props.userBoardNumber === 1,
           user: this.props.users[1],
           logicChipDrawer: this.props.activity ? this.props.activity.boards[1].logicChipDrawer : null,
-          toggleBoard: this.props.userBoardNumber === 1 ? this.toggleBoard : null
+          toggleBoard: this.props.userBoardNumber === 1 ? this.toggleBoard : null,
+          showDebugPins: this.props.showDebugPins,
+          stepping: true
         })
       );
     }

--- a/app/src/views/pic/app.js
+++ b/app/src/views/pic/app.js
@@ -128,7 +128,7 @@ module.exports = React.createClass({
     }
 
     // update the wires
-    wires = (boardInfo ? boardInfo.wires : null) || [];
+    wires = (boardInfo && boardInfo.layout ? boardInfo.layout.wires : null) || [];
     board.updateWires(wires);
   },
 

--- a/app/src/views/shared/board.js
+++ b/app/src/views/shared/board.js
@@ -240,7 +240,10 @@ module.exports = React.createClass({
       }
 
       if (callback) {
-        callback(addedWire, moved);
+        if (callback(addedWire, moved)) {
+          // callback can return true to signal a re-render
+          self.setState({wires: self.props.board.wires});
+        }
       }
     };
 
@@ -403,7 +406,7 @@ module.exports = React.createClass({
         chipCY = 37,
         chipX = pageX - this.svgOffset.left - chipCX,
         chipY = pageY - this.svgOffset.top - chipCY,
-        draggingChip = new LogicChip({type: chip.type, layout: {x: chipX, y: chipY, width: 150, height: 75}});
+        draggingChip = new LogicChip({type: chip.type, layout: {x: chipX, y: chipY}});
 
     this.setState({
       selectedWires: [],
@@ -430,7 +433,7 @@ module.exports = React.createClass({
 
     // don't add if hidden by drawer
     if (chip.x < r.right - 100) {
-      var component = new LogicChip({type: chip.type, layout: {x: chip.x, y: chip.y, width: 150, height: 75}, selectable: true});
+      var component = new LogicChip({type: chip.type, layout: {x: chip.x, y: chip.y}, selectable: true});
       this.addLogicChip(component);
       this.setState({draggingChip: null, selectedWires: [], selectedComponents: [component]});
     }

--- a/app/src/views/shared/connector-hole.js
+++ b/app/src/views/shared/connector-hole.js
@@ -13,13 +13,23 @@ module.exports = React.createClass({
     this.props.reportHover(null);
   },
 
+  componentWillMount: function () {
+    this.setState({editableInput: (window.location.search.indexOf('editableInput') !== -1) && !this.props.hole.inputMode && this.props.editable});
+  },
+
   startDrag: function (e) {
-    this.props.drawConnection(this.props.hole, e, this.props.hole.color);
+    var self = this;
+    this.props.drawConnection(this.props.hole, e, this.props.hole.color, function (addedWire, moved) {
+      if (self.state.editableInput && !addedWire && !moved) {
+        self.props.hole.setVoltage(self.props.hole.getVoltage() ? 0 : 5);
+        return true; // signal a render
+      }
+    });
   },
 
   render: function () {
     var enableHandlers = this.props.selected && this.props.editable;
-    return g({}, circle({cx: this.props.hole.cx, cy: this.props.hole.cy, r: this.props.hole.radius, fill: this.props.hole.getColor(), onMouseDown: enableHandlers ? this.startDrag : null, onMouseOver: enableHandlers ? this.mouseOver : null, onMouseOut: enableHandlers ? this.mouseOut : null},
+    return g({}, circle({cx: this.props.hole.cx, cy: this.props.hole.cy, r: this.props.hole.radius, fill: this.props.hole.getColor(this.state.editableInput), onMouseDown: enableHandlers ? this.startDrag : null, onMouseOver: enableHandlers ? this.mouseOver : null, onMouseOut: enableHandlers ? this.mouseOut : null},
       title({}, this.props.hole.label)
     ));
   }

--- a/app/src/views/shared/pin.js
+++ b/app/src/views/shared/pin.js
@@ -39,8 +39,8 @@ module.exports = React.createClass({
         outputRect = {x: pin.x + (pin.width / 2), y: pin.y, width: pin.width / 2, height: pin.height};
         break;
       default:
-        outputRect = {x: pin.x, y: pin.y, width: pin.width / 2, height: pin.height};
         inputRect = {x: pin.x + (pin.width / 2), y: pin.y, width: pin.width / 2, height: pin.height};
+        outputRect = {x: pin.x, y: pin.y, width: pin.width / 2, height: pin.height};
         break;
     }
 

--- a/app/src/views/shared/probe.js
+++ b/app/src/views/shared/probe.js
@@ -1,7 +1,9 @@
 var events = require('../shared/events'),
     g = React.DOM.g,
     path = React.DOM.path,
-    circle = React.DOM.circle;
+    circle = React.DOM.circle,
+    rect = React.DOM.rect,
+    text = React.DOM.text;
 
 module.exports = React.createClass({
   displayName: 'ProbeView',
@@ -91,6 +93,17 @@ module.exports = React.createClass({
     };
     return pos;
   },
+  
+  // copied from http://stackoverflow.com/a/9232092
+  truncateDecimals: function (num, digits) {
+    var numS = num.toString(),
+        decPos = numS.indexOf('.'),
+        substrLength = decPos == -1 ? numS.length : 1 + decPos + digits,
+        trimmedResult = numS.substr(0, substrLength),
+        finalResult = isNaN(trimmedResult) ? 0 : trimmedResult;
+
+    return parseFloat(finalResult);
+  },
 
   render: function () {
     var selectedConstants = this.props.constants.selectedConstants(this.props.selected),
@@ -105,9 +118,12 @@ module.exports = React.createClass({
         redFill = defaultFill,
         greenFill = defaultFill,
         amberFill = defaultFill,
+        voltage = "--",
         needlePath, handlePath, rotation;
 
     if (this.props.probeSource && (!this.props.probeSource.inputMode || this.props.probeSource.connected)) {
+
+      voltage = this.truncateDecimals(this.props.probeSource.voltage, 2);
 
       if (this.props.probeSource.isHigh()) {
         redFill = 1;
@@ -160,9 +176,11 @@ module.exports = React.createClass({
     return g({transform: ['rotate(', rotation, ' ',  x, ' ', y + (height / 2), ')'].join(''), onMouseDown: this.props.selected && this.props.editable ? this.startDrag : null},
       path({d: needlePath, fill: '#c0c0c0', stroke: '#777', style: {pointerEvents: 'none'}}),
       path({d: handlePath, fill: '#eee', stroke: '#777'}), // '#FDCA6E'
-      circle({cx: x + (4 * height), cy: middleY, r: height / 4, fill: 'red', fillOpacity: redFill}),
-      circle({cx: x + (5 * height), cy: middleY, r: height / 4, fill: 'green', fillOpacity: greenFill}),
-      circle({cx: x + (6 * height), cy: middleY, r: height / 4, fill: '#ffbf00', fillOpacity: amberFill})
+      rect({x: x + (2 * height), y: y + (0.15 * height), width: (2 * height), height: (0.7 * height), stroke: '#555', fill: '#ddd'}),
+      text({x: x + (3 * height), y: middleY + 1, fontSize: selectedConstants.PROBE_HEIGHT * 0.6, fill: '#000', style: {textAnchor: 'middle'}, dominantBaseline: 'middle'}, voltage),
+      circle({cx: x + (4.75 * height), cy: middleY, r: height / 4, fill: 'red', stroke: '#ccc', fillOpacity: redFill}),
+      circle({cx: x + (5.75 * height), cy: middleY, r: height / 4, fill: 'green', stroke: '#ccc', fillOpacity: greenFill}),
+      circle({cx: x + (6.75 * height), cy: middleY, r: height / 4, fill: '#ffbf00', stroke: '#ccc', fillOpacity: amberFill})
     );
   }
 });

--- a/app/src/views/shared/ribbon.js
+++ b/app/src/views/shared/ribbon.js
@@ -12,6 +12,7 @@ module.exports = React.createClass({
         hole, i;
 
     if (this.props.connector) {
+      this.props.connector.calculatePosition(this.props.constants, this.props.selected);
       for (i = 0; i < this.props.connector.holes.length; i++) {
         hole = this.props.connector.holes[i];
         if (!hole.forcedValue) {


### PR DESCRIPTION
The demo control allows you to add all the components and wires with one button click.  The layout is defined in the activity json.

This also fixes a few bugs [#118940367] [#121079609] [#119397463] and adds a debugging aid:

1. The wires and components are now sent as one object to Firebase.  Before they were two objects which sometimes caused a race condition on the updates since the wires need the components in place first.
2. The 7411 output pin spec was incorrect causing the chip not to resolve correctly.
3. The debug pin colors were rotated 90 degrees for the logic chips since they are also rotated 90 degrees.
4. The component map and list were not being properly cleared when the board was cleared.
5. The logic chip size and width were set to a default size in the model instead of making it a option.  When they were an option there was a race condition between the calculation of the pins and the rendering.
6. The ribbons now force a calculation of the connector layout to avoid a race condition.
7. The voltage is now being displayed on the probe
8. A query option of editableInput was added to help debug complex circuits