### PR TITLE
Remove two board limitation in logic gate activity [#127831709]

### DIFF
--- a/activities/logic-gates/adder.json
+++ b/activities/logic-gates/adder.json
@@ -1,8 +1,5 @@
 {
   "name": "Adder",
-  "input": ["A", "B", "C"],
-  "ribbon": ["A", "B", "C", "D", "E", "F", "G"],
-  "output": ["Sum", "Carry"],
   "boards": [
     {
       "logicChipDrawer": {
@@ -12,6 +9,8 @@
           "7408": {"max": 3}
         }
       },
+      "input": ["A", "B", "C"],
+      "output": ["A", "B", "C", "D", "E", "F", "G"],
       "demo": {
         "chips": {
           "not": {
@@ -36,41 +35,41 @@
           }
         },
         "wires": [
-          "in:1,not:13",   "// create NOT A on not pin 12",
-          "in:2,not:11",   "// create NOT A on not pin 12",
-          "in:3,not:9",   "// create NOT A on not pin 12",
+          "input:A,not:13",     "// create NOT A on not pin 12",
+          "input:B,not:11",     "// create NOT A on not pin 12",
+          "input:C,not:9",      "// create NOT A on not pin 12",
 
-          "in:1,3and1:13",  "// A to 3 and input",
-          "not:10,3and1:1", "// NOT B to 3 and input",
-          "not:8,3and1:2",  "// NOT C to 3 and input",
-          "3and1:12,out:1",  "// (A AND NOT B AND NOT C) to output",
+          "input:A,3and1:13",   "// A to 3 and input",
+          "not:10,3and1:1",     "// NOT B to 3 and input",
+          "not:8,3and1:2",      "// NOT C to 3 and input",
+          "3and1:12,output:A",  "// (A AND NOT B AND NOT C) to output",
 
-          "not:12,3and1:11",  "// NOT A to 3 and input",
-          "in:2,3and1:10", "// B to 3 and input",
-          "not:8,3and1:9",  "// NOT C to 3 and input",
-          "3and1:8,out:2",  "// (NOT A AND B AND NOT C) to output",
+          "not:12,3and1:11",   "// NOT A to 3 and input",
+          "input:B,3and1:10",  "// B to 3 and input",
+          "not:8,3and1:9",     "// NOT C to 3 and input",
+          "3and1:8,output:B",  "// (NOT A AND B AND NOT C) to output",
 
-          "not:12,3and1:3",  "// NOT A to 3 and input",
-          "not:10,3and1:4", "// NOT B to 3 and input",
-          "in:3,3and1:5",  "// C to 3 and input",
-          "3and1:6,out:3",  "// (NOT A AND B AND C) to output",
+          "not:12,3and1:3",    "// NOT A to 3 and input",
+          "not:10,3and1:4",    "// NOT B to 3 and input",
+          "input:C,3and1:5",   "// C to 3 and input",
+          "3and1:6,output:C",  "// (NOT A AND B AND C) to output",
 
-          "in:1,3and2:11",  "// A to 3 and input",
-          "in:2,3and2:10", "// B to 3 and input",
-          "in:3,3and2:9",  "// C to 3 and input",
-          "3and2:8,out:4",  "// (A AND B AND C) to output",
+          "input:A,3and2:11",  "// A to 3 and input",
+          "input:B,3and2:10",  "// B to 3 and input",
+          "input:C,3and2:9",   "// C to 3 and input",
+          "3and2:8,output:D",  "// (A AND B AND C) to output",
 
-          "in:1,2and:13",  "// A to 2 and input",
-          "in:2,2and:12", "// B to 2 and input",
-          "2and:11,out:5", "// (A AND B) to output",
+          "input:A,2and:13",   "// A to 2 and input",
+          "input:B,2and:12",   "// B to 2 and input",
+          "2and:11,output:E",  "// (A AND B) to output",
 
-          "in:2,2and:10",  "// B to 2 and input",
-          "in:3,2and:9", "// C to 2 and input",
-          "2and:8,out:6", "// (B AND C) to output",
+          "input:B,2and:10",   "// B to 2 and input",
+          "input:C,2and:9",    "// C to 2 and input",
+          "2and:8,output:F",   "// (B AND C) to output",
 
-          "in:1,2and:1",  "// A to 2 and input",
-          "in:3,2and:2", "// C to 2 and input",
-          "2and:3,out:7", "// (A AND C) to output"
+          "input:A,2and:1",    "// A to 2 and input",
+          "input:C,2and:2",    "// C to 2 and input",
+          "2and:3,output:G",   "// (A AND C) to output"
         ]
       }
     },
@@ -80,6 +79,8 @@
           "7432": {"max": 5}
         }
       },
+      "input": ["A", "B", "C", "D", "E", "F", "G"],
+      "output": ["Sum", "Carry"],
       "demo": {
         "chips": {
           "or1": {
@@ -94,23 +95,23 @@
           }
         },
         "wires": [
-          "in:1,or1:13",   "// (A AND NOT B AND NOT C) to or input",
-          "in:2,or1:12",   "// (NOT A AND B AND NOT C) to or input",
+          "input:A,or1:13",   "// (A AND NOT B AND NOT C) to or input",
+          "input:B,or1:12",   "// (NOT A AND B AND NOT C) to or input",
           "or1:11,or2:13",   "// ((A AND NOT B AND NOT C) OR (NOT A AND B AND NOT C)) to sum or input",
 
-          "in:3,or1:10",   "// (NOT A AND B AND C) to or input",
-          "in:4,or1:9",   "// (A AND B AND C) to or input",
+          "input:C,or1:10",   "// (NOT A AND B AND C) to or input",
+          "input:D,or1:9",   "// (A AND B AND C) to or input",
           "or1:8,or2:12",   "// ((NOT A AND B AND C) OR (A AND B AND C)) to sum or input",
 
-          "in:5,or1:1",   "// (A AND B) to or input",
-          "in:6,or1:2",   "// (B AND C) to or input",
+          "input:E,or1:1",   "// (A AND B) to or input",
+          "input:F,or1:2",   "// (B AND C) to or input",
           "or1:3,or2:1",   "// ((A AND B) OR (B AND C)) to carry or input",
 
-          "in:7,or2:2",   "// (A AND C) to carry or input",
+          "input:G,or2:2",   "// (A AND C) to carry or input",
 
-          "or2:11,out:1",   "// (((A AND NOT B AND NOT C) OR (NOT A AND B AND NOT C)) OR ((NOT A AND B AND C) OR (A AND B AND C))) to sum output",
+          "or2:11,output:Sum",   "// (((A AND NOT B AND NOT C) OR (NOT A AND B AND NOT C)) OR ((NOT A AND B AND C) OR (A AND B AND C))) to sum output",
 
-          "or2:3,out:2",   "// (((A AND B) OR (B AND C)) OR (A AND C)) to carry output"
+          "or2:3,output:Carry",   "// (((A AND B) OR (B AND C)) OR (A AND C)) to carry output"
         ]
       }
     }

--- a/activities/logic-gates/single-xor.json
+++ b/activities/logic-gates/single-xor.json
@@ -1,8 +1,5 @@
 {
   "name": "Single XOR",
-  "input": ["A", "B"],
-  "ribbon": ["A", "B"],
-  "output": ["XOR"],
   "boards": [
     {
       "logicChipDrawer": {
@@ -11,6 +8,8 @@
           "7404": {"max": 3}
         }
       },
+      "input": ["A", "B"],
+      "output": ["C", "D"],
       "demo": {
         "chips": {
           "not": {
@@ -25,14 +24,14 @@
           }
         },
         "wires": [
-          "in:1,not:13",   "// create NOT A on not pin 12",
-          "in:2,not:9",    "// create NOT B on not pin 8",
+          "input:A,not:13",   "// create NOT A on not pin 12",
+          "input:B,not:9",    "// create NOT B on not pin 8",
           "not:12,and:13", "// NOT A to and pin 13",
-          "in:2,and:12",   "// B to and pin 12",
-          "and:11,out:1",  "// (NOT A AND B) to output hole 1",
+          "input:B,and:12",   "// B to and pin 12",
+          "and:11,output:C",  "// (NOT A AND B) to output hole 1",
           "not:8,and:10",  "// NOT B to and pin 10",
-          "in:1,and:9",    "// A to and pin 9",
-          "and:8,out:2",   "// (NOT B AND A) to output hole 2"
+          "input:A,and:9",    "// A to and pin 9",
+          "and:8,output:D",   "// (NOT B AND A) to output hole 2"
         ]
       }
     },
@@ -42,6 +41,8 @@
           "7432": {"max": 2}
         }
       },
+      "input": ["C", "D"],
+      "output": ["XOR"],
       "demo": {
         "chips": {
           "or": {
@@ -51,9 +52,9 @@
           }
         },
         "wires": [
-          "in:1,or:13",  "// C = (NOT A AND B) from input hole 1",
-          "in:2,or:12",  "// D = (NOT B AND A) from input hole 2",
-          "or:11,out:1", "// (C OR D) to output hole 1"
+          "input:C,or:13",  "// C = (NOT A AND B) from input hole 1",
+          "input:D,or:12",  "// D = (NOT B AND A) from input hole 2",
+          "or:11,output:XOR", "// (C OR D) to output hole 1"
         ]
       }
     }

--- a/activities/logic-gates/three-board-xor.json
+++ b/activities/logic-gates/three-board-xor.json
@@ -1,0 +1,87 @@
+{
+  "name": "Three Board XOR",
+  "boards": [
+    {
+      "logicChipDrawer": {
+        "chips": {
+          "7404": {"max": 3}
+        }
+      },
+      "input": ["A", "B"],
+      "output": ["A", "B", "NOT A", "NOT B"],
+      "demo": {
+        "chips": {
+          "not": {
+            "type": "7404",
+            "x": 300,
+            "y": 150
+          }
+        },
+        "wires": [
+          "input:A,not:13",      "// create NOT A on not pin 12",
+          "input:B,not:9",       "// create NOT B on not pin 8",
+          "input:A,output:A",    "// A to output hole 1",
+          "input:B,output:B",    "// B to output hole 2",
+          "not:12,output:NOT A", "// NOT A to output hole 3",
+          "not:8,output:NOT B",  "// NOT B to output hole 4"
+        ]
+      }
+    },
+    {
+      "logicChipDrawer": {
+        "chips": {
+          "7408": {"max": 2}
+        }
+      },
+      "input": ["A", "B", "NOT A", "NOT B"],
+      "output": ["C", "D"],
+      "demo": {
+        "chips": {
+          "and": {
+            "type": "7408",
+            "x": 300,
+            "y": 150
+          }
+        },
+        "wires": [
+          "input:NOT A,and:13", "// NOT A to and pin 13",
+          "input:B,and:12",     "// B to and pin 12",
+          "and:11,output:C",    "// (NOT A AND B) to output hole 1",
+          "input:NOT B,and:10", "// NOT B to and pin 10",
+          "input:A,and:9",      "// A to and pin 9",
+          "and:8,output:D",     "// (NOT B AND A) to output hole 2"
+        ]
+      }
+    },
+    {
+      "logicChipDrawer": {
+        "chips": {
+          "7432": {"max": 2}
+        }
+      },
+      "input": ["C", "D"],
+      "output": ["XOR"],
+      "demo": {
+        "chips": {
+          "or": {
+            "type": "7432",
+            "x": 300,
+            "y": 150
+          }
+        },
+        "wires": [
+          "input:C,or:13",    "// C = (NOT A AND B) from input hole 1",
+          "input:D,or:12",    "// D = (NOT B AND A) from input hole 2",
+          "or:11,output:XOR", "// (C OR D) to output hole 1"
+        ]
+      }
+    }
+  ],
+  "truthTable": [
+    ["input:A", "input:B", "output:XOR"],
+    [0, 0, 0],
+    [0, 1, 1],
+    [1, 0, 1],
+    [1, 1, 0]
+  ]
+}

--- a/app/public/css/tt.css
+++ b/app/public/css/tt.css
@@ -504,8 +504,9 @@ form button:disabled {
 
 #connection-status {
   margin: 0 auto;
-  width: 10em;
+  width: 70px;
   margin-top: 1em;
+  margin-bottom: 1em;
   font-size: 0.9em;
 }
 
@@ -588,4 +589,8 @@ form button:disabled {
 
 .circuit-board {
   width: 740px;
+}
+
+.ribbon {
+  background-color: #ddd;
 }

--- a/app/src/views/logic-gates/workspace.js
+++ b/app/src/views/logic-gates/workspace.js
@@ -36,7 +36,8 @@ module.exports = React.createClass({
   },
 
   render: function () {
-    var selectedConstants;
+    var selectedConstants,
+        ribbonsAndBoards, i;
 
     if (this.props.userBoardNumber == -1) {
       return div({id: 'workspace', style: {width: this.props.constants.WORKSPACE_WIDTH}});
@@ -70,36 +71,25 @@ module.exports = React.createClass({
       );
     }
     else {
-      return div({id: 'workspace', style: {width: this.props.constants.WORKSPACE_WIDTH}},
-        RibbonView({
+      selectedConstants = this.props.constants.selectedConstants(false);
+      ribbonsAndBoards = [];
+      for (i = 0; i < this.props.boards.length; i++) {
+        ribbonsAndBoards.push(RibbonView({
           constants: this.props.constants,
-          connector: this.props.boards[0].connectors.input
-        }),
-        BoardView({
+          connector: this.props.boards[i].connectors.input
+        }));
+        ribbonsAndBoards.push(BoardView({
           constants: this.props.constants,
-          board: this.props.boards[0],
-          editable: this.props.userBoardNumber === 0,
-          user: this.props.users[0],
-          logicChipDrawer: this.props.activity ? this.props.activity.boards[0].logicChipDrawer : null,
-          toggleBoard: this.props.userBoardNumber === 0 ? this.toggleBoard : null,
+          board: this.props.boards[i],
+          editable: this.props.userBoardNumber === i,
+          user: this.props.users[i],
+          logicChipDrawer: this.props.activity ? this.props.activity.boards[i].logicChipDrawer : null,
+          toggleBoard: this.props.userBoardNumber === i ? this.toggleBoard : null,
           showDebugPins: this.props.showDebugPins,
           stepping: true
-        }),
-        RibbonView({
-          constants: this.props.constants,
-          connector: this.props.boards[0].connectors.output
-        }),
-        BoardView({
-          constants: this.props.constants,
-          board: this.props.boards[1],
-          editable: this.props.userBoardNumber === 1,
-          user: this.props.users[1],
-          logicChipDrawer: this.props.activity ? this.props.activity.boards[1].logicChipDrawer : null,
-          toggleBoard: this.props.userBoardNumber === 1 ? this.toggleBoard : null,
-          showDebugPins: this.props.showDebugPins,
-          stepping: true
-        })
-      );
+        }));
+      }
+      return div({id: 'workspace', style: {width: this.props.constants.WORKSPACE_WIDTH, height: (this.props.boards.length * (selectedConstants.BOARD_HEIGHT + this.props.constants.RIBBON_HEIGHT)) + 20}}, ribbonsAndBoards);
     }
   }
 });

--- a/app/src/views/pic/app.js
+++ b/app/src/views/pic/app.js
@@ -324,14 +324,14 @@ module.exports = React.createClass({
       this.state.showWireControls ? WireControlsView({wireSettings: this.state.wireSettings, updateWireSettings: this.updateWireSettings}) : null,
       h1({}, "Teaching Teamwork PIC Activity"),
       this.state.currentUser ? h2({}, "Circuit " + (this.state.currentBoard + 1) + " (User: " + this.state.currentUser + ", Group: " + this.state.currentGroup + ")") : null,
+      OfflineCheckView({}),
       WeGotItView({currentUser: this.state.currentUser, checkIfCircuitIsCorrect: this.checkIfCircuitIsCorrect}),
       div({id: 'picapp'},
         WorkspaceView({constants: constants, boards: this.state.boards, stepping: !this.state.running, showDebugPins: this.state.showDebugPins, users: this.state.users, userBoardNumber: this.state.userBoardNumber, wireSettings: this.state.wireSettings}),
         this.state.showSimulator ? SimulatorControlView({running: this.state.running, run: this.run, step: this.step, reset: this.reset}) : null,
         this.state.showDemo ? DemoControlView({top: demoTop, running: this.state.running, toggleAllWires: this.toggleAllWires, toggleDebugPins: this.toggleDebugPins, showDebugPins: this.state.showDebugPins, addedAllWires: this.state.addedAllWires}) : null,
         SidebarChatView({numClients: 3, top: sidebarTop})
-      ),
-      OfflineCheckView({})
+      )
     );
   }
 });

--- a/app/src/views/shared/ribbon.js
+++ b/app/src/views/shared/ribbon.js
@@ -20,7 +20,7 @@ module.exports = React.createClass({
         }
       }
     }
-    return div({style: {height: this.props.constants.RIBBON_HEIGHT}},
+    return div({className: 'ribbon', style: {height: this.props.constants.RIBBON_HEIGHT}},
       svg({}, wires)
     );
   }


### PR DESCRIPTION
This commit also:

- Updates the JSON demo authoring to use named input and output pins
- Moves the online/offline image to the top of the screen for better visibility with >2 boards
- Adds a "three-board-xor" test activity to show that 3 boards looks like