### PR TITLE
Change browserify gulp task to not exit on errors

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -11,11 +11,16 @@ var tt_version = package.version;
 var tt_build_date = (new Date()).toString();
 var tt_commit_hash = gitRev.long();
 
+var dontExit = function (err) {
+  this.emit('end');
+};
+
 gulp.task('browserify-breadboard', function(){
   var b = browserify();
   b.transform(reactify); // use the reactify transform
   b.add(config.src.breadboard);
   return b.bundle()
+    .on('error', dontExit)
     .pipe(source('breadboard.js'))
     .pipe(replace('__TT_VERSION__', tt_version))
     .pipe(replace('__TT_BUILD_DATE__', tt_build_date))
@@ -28,6 +33,7 @@ gulp.task('browserify-pic', function(){
   b.transform(reactify); // use the reactify transform
   b.add(config.src.pic);
   return b.bundle()
+    .on('error', dontExit)
     .pipe(source('pic.js'))
     .pipe(replace('__TT_VERSION__', tt_version))
     .pipe(replace('__TT_BUILD_DATE__', tt_build_date))
@@ -40,6 +46,7 @@ gulp.task('browserify-logic-gates', function(){
   b.transform(reactify); // use the reactify transform
   b.add(config.src.logicGates);
   return b.bundle()
+    .on('error', dontExit)
     .pipe(source('logic-gates.js'))
     .pipe(replace('__TT_VERSION__', tt_version))
     .pipe(replace('__TT_BUILD_DATE__', tt_build_date))


### PR DESCRIPTION
This was done as part of the scheduled weekly tech-debt cleanup.