### PR TITLE
Fixed chip deletes and chip counts [#140139707]

### DIFF
--- a/app/src/models/shared/board.js
+++ b/app/src/models/shared/board.js
@@ -322,6 +322,10 @@ Board.prototype.updateComponents = function (newSerializedComponents) {
       this.removeWire(wire.source, wire.dest);
     }
 
+    if (component instanceof LogicChip) {
+      self.removeComponent(component);
+    }
+
     delete this.components[name];
   }
   $.each(newSerializedComponents, function (name, serializeComponent) {

--- a/app/src/views/shared/board.js
+++ b/app/src/views/shared/board.js
@@ -33,7 +33,6 @@ module.exports = React.createClass({
       drawBox: null,
       draggingProbe: false,
       draggingChip: null,
-      logicChipDrawer: this.initLogicChipDrawer(this.props.logicChipDrawer),
       nextChipNumber: 0
     };
   },
@@ -47,25 +46,10 @@ module.exports = React.createClass({
     this.svgOffset = $(this.refs.svg).offset();
   },
 
-  componentWillReceiveProps: function (nextProps) {
-    if (!this.state.logicChipDrawer && nextProps.logicChipDrawer) {
-      this.setState({logicChipDrawer: this.initLogicChipDrawer(nextProps.logicChipDrawer)});
-    }
-  },
-
   componentWillUnmount: function () {
     boardWatcher.removeListener(this.props.board, this.updateWatchedBoard);
     $(window).off('keyup', this.keyUp);
     $(window).off('keydown', this.keyDown);
-  },
-
-  initLogicChipDrawer: function (rawData) {
-    if (rawData) {
-      $.each(rawData.chips, function (type, chip) {
-        chip.count = 0;
-      });
-    }
-    return rawData;
   },
 
   chatHasFocus: function () {
@@ -447,27 +431,18 @@ module.exports = React.createClass({
   },
 
   addLogicChip: function (chip, name) {
-    var logicChipDrawer = this.state.logicChipDrawer;
-
     name = name || "lc" + this.state.nextChipNumber;
     this.props.board.addComponent(name, chip);
     events.logEvent(events.ADD_LOGIC_CHIP_EVENT, null, {board: this.props.board, chip: chip});
 
-    logicChipDrawer.chips[chip.type].count++;
     this.setState({
-      logicChipDrawer: logicChipDrawer,
       nextChipNumber: this.state.nextChipNumber + 1
     });
   },
 
   removeLogicChip: function (chip) {
-    var logicChipDrawer = this.state.logicChipDrawer;
-
     this.props.board.removeComponent(chip);
     events.logEvent(events.REMOVE_LOGIC_CHIP_EVENT, null, {board: this.props.board, chip: chip});
-
-    logicChipDrawer.chips[chip.type].count--;
-    this.setState({logicChipDrawer: logicChipDrawer});
   },
 
   componentSelected: function (component) {
@@ -538,7 +513,7 @@ module.exports = React.createClass({
         (this.state.drawConnection ? path({d: layout.getBezierPath({x1: this.state.drawConnection.x1, x2: this.state.drawConnection.x2, y1: this.state.drawConnection.y1, y2: this.state.drawConnection.y2, reflection: this.state.drawConnection.reflection, wireSettings: this.props.wireSettings}), stroke: this.state.drawConnection.stroke, strokeWidth: this.state.drawConnection.strokeWidth, fill: 'none', style: {pointerEvents: 'none'}}) : null),
 
         (this.state.drawBox ? path({d: this.state.drawBox.path, stroke: this.state.drawBox.stroke, strokeWidth: this.state.drawBox.strokeWidth, strokeDasharray: this.state.drawBox.strokeDasharray, fill: 'none', style: {pointerEvents: 'none'}}) : null),
-        this.state.logicChipDrawer && this.props.editable && this.props.selected ? LogicChipDrawerView({chips: this.state.logicChipDrawer.chips, selected: this.props.selected, editable: this.props.editable, startDrag: this.startLogicChipDrawerDrag, layout: selectedConstants.LOGIC_DRAWER_LAYOUT}) : null,
+        this.props.logicChipDrawer && this.props.editable && this.props.selected ? LogicChipDrawerView({board: this.props.board, drawer: this.props.logicChipDrawer, selected: this.props.selected, editable: this.props.editable, startDrag: this.startLogicChipDrawerDrag, layout: selectedConstants.LOGIC_DRAWER_LAYOUT}) : null,
         this.props.showProbe ? ProbeView({constants: this.props.constants, board: this.props.board, selected: this.props.selected, editable: this.props.editable, stepping: this.props.stepping, probeSource: this.state.probeSource, hoverSource: this.state.hoverSource, pos: this.state.probePos, setProbe: this.setProbe, svgOffset: this.svgOffset, draggingProbe: this.draggingProbe}) : null,
         this.state.draggingChip ? this.state.draggingChip.view : null
       ),

--- a/app/src/views/shared/logic-chip-drawer.js
+++ b/app/src/views/shared/logic-chip-drawer.js
@@ -3,6 +3,7 @@ var g = React.DOM.g,
     text = React.DOM.text,
     title = React.DOM.title,
     path = React.DOM.path,
+    LogicChip =  require('../../models/logic-gates/logic-chip'),
     chipNames = require('../../data/logic-gates/chip-names'),
     ChipView;
 
@@ -53,7 +54,7 @@ module.exports = React.createClass({
   getInitialState: function () {
     return {
       scrollSteps: 0,
-      maxScrollSteps: Object.keys(this.props.chips).length - 3
+      maxScrollSteps: Object.keys(this.props.drawer.chips).length - 3
     };
   },
 
@@ -93,7 +94,7 @@ module.exports = React.createClass({
         chipWidth = this.props.layout.width * 0.6,
         chipHeight = chipWidth * 1.5,
         chipMargin = (this.props.layout.width - chipWidth) / 2,
-        numChips = Object.keys(this.props.chips).length,
+        numChips = Object.keys(this.props.drawer.chips).length,
         totalHeight = (numChips * chipHeight) + ((numChips - 1) * chipMargin),
         needsScroller = totalHeight > this.props.layout.height,
         chipX = this.props.layout.x + chipMargin,
@@ -104,6 +105,7 @@ module.exports = React.createClass({
         triangleWidth = scrollButtonHeight / 2,
         triangleHeight = scrollButtonHeight / 2,
         triangleX = this.props.layout.x + ((this.props.layout.width - triangleWidth) / 2),
+        chipCounts = {},
         triangleY, trianglePath, i;
 
     if (needsScroller) {
@@ -127,8 +129,15 @@ module.exports = React.createClass({
       chipY = this.props.layout.y + ((this.props.layout.height - ((numChips * chipHeight) + ((numChips - 1) * chipMargin))) / 2);
     }
 
+    $.each(this.props.board.componentList, function (index, component) {
+      if (component instanceof LogicChip) {
+        chipCounts[component.type] = (chipCounts[component.type] || 0) + 1;
+      }
+    });
+
     i = 0;
-    $.each(this.props.chips, function (type, chip) {
+    $.each(this.props.drawer.chips, function (type, chipInfo) {
+      var chip = {count: chipCounts[type] || 0, max: chipInfo.max};
       chips.push(ChipView({key: 'chip' + i, type: type, chip: chip, x: chipX, y: chipY + (i * (chipHeight + chipMargin)), width: chipWidth, height: chipHeight, selected: self.props.selected, editable: self.props.editable, startDrag: self.props.startDrag, onWheel: self.onWheel}));
       i++;
     });


### PR DESCRIPTION
The remote chip delete path was not calling removeComponent() which it now is.   In some cases this caused the chip to be removed from the board but all the wires attached to the chip would remain.  Also moved the logic chip drawer chip counting code directly into the view as a computed value so that when a client reconnects the chip count is not reset to 0.