### PR TITLE
Upgrade React to latest version [#157297814]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "jsonlint": "1.6.0",
     "mathjs": "1.4.0",
     "jquery.cookie": "1.4.1",
-    "react": "15.4.1"
+    "react": "16.1.0"
   }
 }


### PR DESCRIPTION
Upgraded to latest version in Bower (16.1.0).  The react-bower repo has frozen at 16.1.0 and will no longer be updated.

https://github.com/reactjs/react-bower