### PR TITLE
Downgrade React to last 15.x version [#157297814]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "jsonlint": "1.6.0",
     "mathjs": "1.4.0",
     "jquery.cookie": "1.4.1",
-    "react": "16.1.0"
+    "react": "15.6.1"
   }
 }


### PR DESCRIPTION
Previously React was upgraded to 16 but this code makes use of extensive React.createClass() calls which are deprecated in 16.