### PR TITLE
Fix chips not updating when moved [#157062819]

### DIFF
--- a/app/src/models/shared/board.js
+++ b/app/src/models/shared/board.js
@@ -364,6 +364,13 @@ Board.prototype.updateComponents = function(newSerializedComponents) {
     });
 
     this.updateComponentList();
+
+    // place components again to update the breadboard component state
+    if (this.breadboard) {
+        this.componentList.forEach(function (component) {
+            self.breadboard.placeComponent(component);
+        });
+    }
 };
 Board.prototype.serializeInputs = function() {
     var serialized = [];


### PR DESCRIPTION
The code that handled Firebase updates to the component list did not
update the internal breadboard state causing the logic chip pins to
remain connected to breadboard holes when they were moved.