### PR TITLE
Change version number to build number [#120136869]

### DIFF
--- a/app/public/css/tt.css
+++ b/app/public/css/tt.css
@@ -679,14 +679,11 @@ form button:disabled {
   margin: 10px 0;
 }
 .version-info a {
-  transition: opacity 0.5s ease;
   text-decoration: none;
-  margin-top: 5px;
   color: #aaa;
-  opacity: 0;
 }
 .version-info a:hover {
-  opacity: 1;
+  text-decoration: underline;
 }
 
 body.homepage {

--- a/app/src/controllers/shared/log.js
+++ b/app/src/controllers/shared/log.js
@@ -114,6 +114,9 @@ var logManagerUrl  = '//teaching-teamwork-log-manager.herokuapp.com/api/logs',
       data.levelName = data.activity;
       delete data.activity;
 
+      // add the build info
+      data.build = '__TT_COMMIT_HASH__';
+
       // flatten parameters
       if (data.parameters) {
         for (var prop in data.parameters) {

--- a/app/src/views/shared/version.js
+++ b/app/src/views/shared/version.js
@@ -6,23 +6,15 @@ var div = React.DOM.div,
 module.exports = React.createClass({
   displayName: 'Version',
 
-  renderGitCommit: function () {
-    var commitHash = '__TT_COMMIT_HASH__';
-
-    if (commitHash[0] != '_') {
-      return div({className: 'version-info'},
-        a({href: 'https://github.com/concord-consortium/teaching-teamwork/commit/' + commitHash, target: '_blank'}, 'Commit: ' + commitHash)
-      );
-    }
-    else {
-      return null;
-    }
-  },
-
   render: function() {
+    var commitHash = '__TT_COMMIT_HASH__',
+        version = commitHash.substr(0, 8);
+
     return div({className: "version-wrapper"},
-      div({className: 'version-info'}, 'Version __TT_VERSION__, built on __TT_BUILD_DATE__'),
-      this.renderGitCommit()
+      div({className: 'version-info'},
+        'Build ',
+        a({href: 'https://github.com/concord-consortium/teaching-teamwork/commit/' + commitHash, target: '_blank', title: commitHash}, version),
+        ', built on __TT_BUILD_DATE__')
     );
   }
 });

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -3,11 +3,9 @@ var browserify  = require('browserify');
 var source      = require("vinyl-source-stream");
 var reactify    = require('reactify');
 var config      = require('../config').js;
-var package     = require('../../package.json');
 var replace     = require('gulp-replace');
-var gitRev      = require('git-rev-sync')
+var gitRev      = require('git-rev-sync');
 
-var tt_version = package.version;
 var tt_build_date = (new Date()).toString();
 var tt_commit_hash = gitRev.long();
 
@@ -23,7 +21,6 @@ gulp.task('browserify-breadboard', function(){
   return b.bundle()
     .on('error', dontExit)
     .pipe(source('breadboard.js'))
-    .pipe(replace('__TT_VERSION__', tt_version))
     .pipe(replace('__TT_BUILD_DATE__', tt_build_date))
     .pipe(replace('__TT_COMMIT_HASH__', tt_commit_hash))
     .pipe(gulp.dest(config.dest));
@@ -36,7 +33,6 @@ gulp.task('browserify-pic', function(){
   return b.bundle()
     .on('error', dontExit)
     .pipe(source('pic.js'))
-    .pipe(replace('__TT_VERSION__', tt_version))
     .pipe(replace('__TT_BUILD_DATE__', tt_build_date))
     .pipe(replace('__TT_COMMIT_HASH__', tt_commit_hash))
     .pipe(gulp.dest(config.dest));
@@ -49,7 +45,6 @@ gulp.task('browserify-logic-gates', function(){
   return b.bundle()
     .on('error', dontExit)
     .pipe(source('logic-gates.js'))
-    .pipe(replace('__TT_VERSION__', tt_version))
     .pipe(replace('__TT_BUILD_DATE__', tt_build_date))
     .pipe(replace('__TT_COMMIT_HASH__', tt_commit_hash))
     .pipe(gulp.dest(config.dest));


### PR DESCRIPTION
Instead of using the package.json version as the displayed version
number in the footer the first 8 characters of the commit hash is shown
as a link to the commit on GitHub.  This was previously a hidden link in
the footer.

The full commit hash is also recoreded under "build" in the log manager
parameters.