### PR TITLE
Fixed clearing of all unknown value listeners when submit button is closed

### DIFF
--- a/app/src/views/breadboard/submitButton.js
+++ b/app/src/views/breadboard/submitButton.js
@@ -136,7 +136,7 @@ module.exports = SubmitButton = React.createClass({
     this.submitRef.off();
     this.clientListRef.off();
     if (this.usersRef) {
-      this.usersRef.off();
+      this.usersRef.off("value", listenForUnknownValues);
     }
     userController.listenForUnknownValues = null;
   },
@@ -407,7 +407,7 @@ Popup = React.createFactory(React.createClass({
 
   componentWillUnmount: function () {
     if (this.usersRef) {
-      this.usersRef.off();
+      this.usersRef.off("value", listenForUnknownValues);
     }
   },
 


### PR DESCRIPTION
This caused the correct/incorrect state of the unknown values not to be updated if the submit button was pressed before they were entered.